### PR TITLE
Add account management and theme/language toggles

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,0 +1,82 @@
+<?php
+require_once 'auth.php';
+
+$password_msg = '';
+$add_msg = '';
+
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    if($_POST['action'] === 'change_password'){
+        $current = $_POST['current_password'] ?? '';
+        $new = $_POST['new_password'] ?? '';
+        $confirm = $_POST['confirm_password'] ?? '';
+        if($new !== $confirm){
+            $password_msg = 'New passwords do not match';
+        } else {
+            $stmt = $pdo->prepare('SELECT password FROM managers WHERE id = ?');
+            $stmt->execute([$_SESSION['manager_id']]);
+            $manager = $stmt->fetch();
+            if($manager && password_verify($current, $manager['password'])){
+                $stmt = $pdo->prepare('UPDATE managers SET password = ? WHERE id = ?');
+                $stmt->execute([password_hash($new, PASSWORD_DEFAULT), $_SESSION['manager_id']]);
+                $password_msg = 'Password updated successfully';
+            } else {
+                $password_msg = 'Current password is incorrect';
+            }
+        }
+    } elseif($_POST['action'] === 'add_manager'){
+        $username = $_POST['username'] ?? '';
+        $password = $_POST['password'] ?? '';
+        if($username && $password){
+            try{
+                $stmt = $pdo->prepare('INSERT INTO managers (username, password) VALUES (?, ?)');
+                $stmt->execute([$username, password_hash($password, PASSWORD_DEFAULT)]);
+                $add_msg = 'Manager added';
+            } catch(PDOException $e){
+                $add_msg = 'Error adding manager';
+            }
+        }
+    }
+}
+
+include 'header.php';
+?>
+<h2 data-i18n="account.title">Account Settings</h2>
+<div class="row">
+  <div class="col-md-6">
+    <h3 data-i18n="account.change_password">Change Password</h3>
+    <?php if($password_msg): ?><div class="alert alert-info"><?php echo htmlspecialchars($password_msg); ?></div><?php endif; ?>
+    <form method="post">
+      <input type="hidden" name="action" value="change_password">
+      <div class="mb-3">
+        <label class="form-label" data-i18n="account.current_password">Current Password</label>
+        <input type="password" name="current_password" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" data-i18n="account.new_password">New Password</label>
+        <input type="password" name="new_password" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" data-i18n="account.confirm_password">Confirm New Password</label>
+        <input type="password" name="confirm_password" class="form-control" required>
+      </div>
+      <button type="submit" class="btn btn-primary" data-i18n="account.change_password_btn">Change Password</button>
+    </form>
+  </div>
+  <div class="col-md-6">
+    <h3 data-i18n="account.add_manager">Add Manager</h3>
+    <?php if($add_msg): ?><div class="alert alert-info"><?php echo htmlspecialchars($add_msg); ?></div><?php endif; ?>
+    <form method="post">
+      <input type="hidden" name="action" value="add_manager">
+      <div class="mb-3">
+        <label class="form-label" data-i18n="account.username">Username</label>
+        <input type="text" name="username" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" data-i18n="account.password">Password</label>
+        <input type="password" name="password" class="form-control" required>
+      </div>
+      <button type="submit" class="btn btn-success" data-i18n="account.add_manager_btn">Add Manager</button>
+    </form>
+  </div>
+</div>
+<?php include 'footer.php'; ?>

--- a/app.js
+++ b/app.js
@@ -1,0 +1,100 @@
+const translations = {
+  en: {
+    'nav.home': 'Team Management',
+    'nav.members': 'Members',
+    'nav.projects': 'Projects',
+    'nav.tasks': 'Tasks',
+    'nav.workload': 'Workload',
+    'nav.account': 'Account',
+    'welcome': 'Welcome',
+    'logout': 'Logout',
+    'login.title': 'Manager Login',
+    'login.username': 'Username',
+    'login.password': 'Password',
+    'login.button': 'Login',
+    'account.title': 'Account Settings',
+    'account.change_password': 'Change Password',
+    'account.current_password': 'Current Password',
+    'account.new_password': 'New Password',
+    'account.confirm_password': 'Confirm New Password',
+    'account.change_password_btn': 'Change Password',
+    'account.add_manager': 'Add Manager',
+    'account.username': 'Username',
+    'account.password': 'Password',
+    'account.add_manager_btn': 'Add Manager',
+    'theme.dark': 'Dark',
+    'theme.light': 'Light'
+  },
+  zh: {
+    'nav.home': '团队管理',
+    'nav.members': '成员',
+    'nav.projects': '项目',
+    'nav.tasks': '任务',
+    'nav.workload': '工作量',
+    'nav.account': '账户',
+    'welcome': '欢迎',
+    'logout': '退出登录',
+    'login.title': '管理员登录',
+    'login.username': '用户名',
+    'login.password': '密码',
+    'login.button': '登录',
+    'account.title': '账户设置',
+    'account.change_password': '修改密码',
+    'account.current_password': '当前密码',
+    'account.new_password': '新密码',
+    'account.confirm_password': '确认新密码',
+    'account.change_password_btn': '修改密码',
+    'account.add_manager': '添加管理员',
+    'account.username': '用户名',
+    'account.password': '密码',
+    'account.add_manager_btn': '添加管理员',
+    'theme.dark': '暗色',
+    'theme.light': '亮色'
+  }
+};
+
+function applyTranslations() {
+  const lang = localStorage.getItem('lang') || 'en';
+  document.documentElement.lang = lang;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    const text = translations[lang][key];
+    if(text) {
+      el.textContent = text;
+    }
+  });
+  const langToggle = document.getElementById('langToggle');
+  if(langToggle) {
+    langToggle.textContent = lang === 'en' ? '中文' : 'English';
+  }
+  const themeToggle = document.getElementById('themeToggle');
+  if(themeToggle) {
+    const theme = localStorage.getItem('theme') || 'light';
+    themeToggle.textContent = translations[lang][theme === 'light' ? 'theme.dark' : 'theme.light'];
+  }
+}
+
+function applyTheme() {
+  const theme = localStorage.getItem('theme') || 'light';
+  document.documentElement.setAttribute('data-bs-theme', theme);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  applyTheme();
+  applyTranslations();
+
+  document.getElementById('langToggle')?.addEventListener('click', () => {
+    const current = localStorage.getItem('lang') || 'en';
+    const next = current === 'en' ? 'zh' : 'en';
+    localStorage.setItem('lang', next);
+    applyTranslations();
+  });
+
+  document.getElementById('themeToggle')?.addEventListener('click', () => {
+    const current = localStorage.getItem('theme') || 'light';
+    const next = current === 'light' ? 'dark' : 'light';
+    localStorage.setItem('theme', next);
+    applyTheme();
+    applyTranslations();
+  });
+});

--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,5 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="app.js"></script>
 </body>
 </html>

--- a/header.php
+++ b/header.php
@@ -1,4 +1,4 @@
-<?php include 'auth.php'; ?>
+<?php include_once 'auth.php'; ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -10,19 +10,22 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
   <div class="container-fluid">
-    <a class="navbar-brand" href="index.php">Team Management</a>
+    <a class="navbar-brand" href="index.php" data-i18n="nav.home">Team Management</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="members.php">Members</a></li>
-        <li class="nav-item"><a class="nav-link" href="projects.php">Projects</a></li>
-        <li class="nav-item"><a class="nav-link" href="tasks.php">Tasks</a></li>
-        <li class="nav-item"><a class="nav-link" href="workload.php">Workload</a></li>
+        <li class="nav-item"><a class="nav-link" href="members.php" data-i18n="nav.members">Members</a></li>
+        <li class="nav-item"><a class="nav-link" href="projects.php" data-i18n="nav.projects">Projects</a></li>
+        <li class="nav-item"><a class="nav-link" href="tasks.php" data-i18n="nav.tasks">Tasks</a></li>
+        <li class="nav-item"><a class="nav-link" href="workload.php" data-i18n="nav.workload">Workload</a></li>
+        <li class="nav-item"><a class="nav-link" href="account.php" data-i18n="nav.account">Account</a></li>
       </ul>
-      <span class="navbar-text me-3">Welcome, <?php echo htmlspecialchars($_SESSION['username']); ?></span>
-      <a class="btn btn-outline-light" href="logout.php">Logout</a>
+      <span class="navbar-text me-3"><span data-i18n="welcome">Welcome</span>, <?php echo htmlspecialchars($_SESSION['username']); ?></span>
+      <button id="langToggle" class="btn btn-outline-light me-2">中文</button>
+      <button id="themeToggle" class="btn btn-outline-light me-2" data-i18n="theme.dark">Dark</button>
+      <a class="btn btn-outline-light" id="logoutLink" href="logout.php" data-i18n="logout">Logout</a>
     </div>
   </div>
 </nav>

--- a/login.php
+++ b/login.php
@@ -26,27 +26,31 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Manager Login</title>
+<title data-i18n="login.title">Manager Login</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body class="bg-light">
+<body>
 <div class="container mt-5">
+  <div class="text-end mb-3">
+    <button id="langToggle" class="btn btn-outline-secondary btn-sm">中文</button>
+    <button id="themeToggle" class="btn btn-outline-secondary btn-sm" data-i18n="theme.dark">Dark</button>
+  </div>
   <div class="row justify-content-center">
     <div class="col-md-4">
       <div class="card">
-        <div class="card-header">Manager Login</div>
+        <div class="card-header" data-i18n="login.title">Manager Login</div>
         <div class="card-body">
           <?php if($error): ?><div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div><?php endif; ?>
           <form method="post">
             <div class="mb-3">
-              <label class="form-label">Username</label>
+              <label class="form-label" data-i18n="login.username">Username</label>
               <input type="text" name="username" class="form-control" required>
             </div>
             <div class="mb-3">
-              <label class="form-label">Password</label>
+              <label class="form-label" data-i18n="login.password">Password</label>
               <input type="password" name="password" class="form-control" required>
             </div>
-            <button type="submit" class="btn btn-primary w-100">Login</button>
+            <button type="submit" class="btn btn-primary w-100" data-i18n="login.button">Login</button>
           </form>
         </div>
       </div>
@@ -54,5 +58,6 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add account settings page for managers to change their password or create additional manager accounts.
- Introduce language (English/Chinese) and theme (dark/light) toggles with preferences stored in browser.
- Update navigation and login views to use translation strings and expose new toggles.

## Testing
- `php -l header.php footer.php login.php account.php`


------
https://chatgpt.com/codex/tasks/task_e_68996b5a3698832a8bcfb7f9d725e3c8