### PR TITLE
Add double confirmation for deletions and persist login

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,6 +53,10 @@ const translations = {
   }
 };
 
+function doubleConfirm(message) {
+  return confirm(message) && confirm('Please confirm again to proceed.');
+}
+
 function applyTranslations() {
   const lang = localStorage.getItem('lang') || 'en';
   document.documentElement.lang = lang;

--- a/config.php
+++ b/config.php
@@ -16,5 +16,11 @@ try {
 } catch (\PDOException $e) {
     throw new \PDOException($e->getMessage(), (int)$e->getCode());
 }
+session_set_cookie_params([
+    'lifetime' => 86400 * 7,
+    'path' => '/',
+    'httponly' => true,
+    'samesite' => 'Lax'
+]);
 session_start();
 ?>

--- a/members.php
+++ b/members.php
@@ -60,7 +60,7 @@ $members = $stmt->fetchAll();
     <td><?= htmlspecialchars($m['homeplace']); ?></td>
     <td>
       <a class="btn btn-sm btn-primary" href="member_edit.php?id=<?= $m['id']; ?>">Edit</a>
-      <a class="btn btn-sm btn-danger" href="member_delete.php?id=<?= $m['id']; ?>" onclick="return confirm('Delete member?');">Delete</a>
+      <a class="btn btn-sm btn-danger" href="member_delete.php?id=<?= $m['id']; ?>" onclick="return doubleConfirm('Delete member?');">Delete</a>
     </td>
   </tr>
   <?php endforeach; ?>

--- a/project_members.php
+++ b/project_members.php
@@ -25,7 +25,7 @@ $members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')-
   <td><?= htmlspecialchars($a['campus_id']); ?></td>
   <td><?= htmlspecialchars($a['name']); ?></td>
   <td><?= htmlspecialchars($a['join_time']); ?></td>
-  <td><a class="btn btn-sm btn-danger" href="project_member_remove.php?log_id=<?= $a['id']; ?>&project_id=<?= $project_id; ?>">Remove</a></td>
+  <td><a class="btn btn-sm btn-danger" href="project_member_remove.php?log_id=<?= $a['id']; ?>&project_id=<?= $project_id; ?>" onclick="return doubleConfirm('Remove member from project?');">Remove</a></td>
 </tr>
 <?php endforeach; ?>
 </table>

--- a/projects.php
+++ b/projects.php
@@ -39,7 +39,7 @@ if($status){
   <td>
     <a class="btn btn-sm btn-primary" href="project_edit.php?id=<?= $p['id']; ?>">Edit</a>
     <a class="btn btn-sm btn-warning" href="project_members.php?id=<?= $p['id']; ?>">Members</a>
-    <a class="btn btn-sm btn-danger" href="project_delete.php?id=<?= $p['id']; ?>" onclick="return confirm('Delete project?');">Delete</a>
+    <a class="btn btn-sm btn-danger" href="project_delete.php?id=<?= $p['id']; ?>" onclick="return doubleConfirm('Delete project?');">Delete</a>
   </td>
 </tr>
 <?php endforeach; ?>

--- a/task_affairs.php
+++ b/task_affairs.php
@@ -22,7 +22,7 @@ $members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')-
   <td><?= htmlspecialchars($a['name']); ?> (<?= htmlspecialchars($a['campus_id']); ?>)</td>
   <td><?= htmlspecialchars($a['start_time']); ?></td>
   <td><?= htmlspecialchars($a['end_time']); ?></td>
-  <td><a class="btn btn-sm btn-danger" href="affair_delete.php?id=<?= $a['id']; ?>&task_id=<?= $task_id; ?>" onclick="return confirm('Delete affair?');">Delete</a></td>
+  <td><a class="btn btn-sm btn-danger" href="affair_delete.php?id=<?= $a['id']; ?>&task_id=<?= $task_id; ?>" onclick="return doubleConfirm('Delete affair?');">Delete</a></td>
 </tr>
 <?php endforeach; ?>
 </table>

--- a/tasks.php
+++ b/tasks.php
@@ -35,7 +35,7 @@ if($status){
   <td>
     <a class="btn btn-sm btn-primary" href="task_edit.php?id=<?= $t['id']; ?>">Edit</a>
     <a class="btn btn-sm btn-warning" href="task_affairs.php?id=<?= $t['id']; ?>">Urgent Affairs</a>
-    <a class="btn btn-sm btn-danger" href="task_delete.php?id=<?= $t['id']; ?>" onclick="return confirm('Delete task?');">Delete</a>
+    <a class="btn btn-sm btn-danger" href="task_delete.php?id=<?= $t['id']; ?>" onclick="return doubleConfirm('Delete task?');">Delete</a>
   </td>
 </tr>
 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- prompt users twice before deleting members, projects, tasks, task affairs, or removing project members
- add reusable `doubleConfirm` helper in app.js
- keep login sessions across browser restarts with persistent cookie settings

## Testing
- `php -l config.php members.php project_members.php projects.php task_affairs.php tasks.php`
- `node --check app.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68999d779a90832abb1d9c744fcd8e85