### PR TITLE
Add research directions and refine workload reporting

### DIFF
--- a/affair_add.php
+++ b/affair_add.php
@@ -3,11 +3,15 @@ include 'auth.php';
 if($_SERVER['REQUEST_METHOD']==='POST'){
     $task_id = $_POST['task_id'];
     $description = $_POST['description'];
-    $member_id = $_POST['member_id'];
+    $member_ids = $_POST['member_ids'] ?? [];
     $start_time = $_POST['start_time'];
     $end_time = $_POST['end_time'];
-    $stmt = $pdo->prepare('INSERT INTO task_affairs(task_id,description,member_id,start_time,end_time) VALUES (?,?,?,?,?)');
-    $stmt->execute([$task_id,$description,$member_id,$start_time,$end_time]);
+    $stmt = $pdo->prepare('INSERT INTO task_affairs(task_id,description,start_time,end_time) VALUES (?,?,?,?)');
+    $stmt->execute([$task_id,$description,$start_time,$end_time]);
+    $affair_id = $pdo->lastInsertId();
+    foreach($member_ids as $mid){
+        $pdo->prepare('INSERT INTO task_affair_members(affair_id,member_id) VALUES (?,?)')->execute([$affair_id,$mid]);
+    }
     header('Location: task_affairs.php?id='.$task_id);
     exit();
 }

--- a/affair_delete.php
+++ b/affair_delete.php
@@ -4,6 +4,7 @@ $id = $_GET['id'] ?? null;
 $task_id = $_GET['task_id'] ?? null;
 if($id){
     $pdo->prepare('DELETE FROM task_affairs WHERE id=?')->execute([$id]);
+    $pdo->prepare('DELETE FROM task_affair_members WHERE affair_id=?')->execute([$id]);
 }
 if($task_id){
     header('Location: task_affairs.php?id='.$task_id);

--- a/database.sql
+++ b/database.sql
@@ -58,9 +58,29 @@ CREATE TABLE task_affairs (
   id INT AUTO_INCREMENT PRIMARY KEY,
   task_id INT NOT NULL,
   description TEXT,
-  member_id INT NOT NULL,
   start_time DATETIME NOT NULL,
   end_time DATETIME NOT NULL,
-  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+
+CREATE TABLE task_affair_members (
+  affair_id INT NOT NULL,
+  member_id INT NOT NULL,
+  PRIMARY KEY (affair_id, member_id),
+  FOREIGN KEY (affair_id) REFERENCES task_affairs(id) ON DELETE CASCADE,
+  FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
+);
+
+CREATE TABLE research_directions (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(100) NOT NULL,
+  description TEXT
+);
+
+CREATE TABLE direction_members (
+  direction_id INT NOT NULL,
+  member_id INT NOT NULL,
+  PRIMARY KEY (direction_id, member_id),
+  FOREIGN KEY (direction_id) REFERENCES research_directions(id) ON DELETE CASCADE,
   FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
 );

--- a/direction_delete.php
+++ b/direction_delete.php
@@ -1,0 +1,10 @@
+<?php
+include 'auth.php';
+$id = $_GET['id'] ?? null;
+if($id){
+    $pdo->prepare('DELETE FROM research_directions WHERE id=?')->execute([$id]);
+    $pdo->prepare('DELETE FROM direction_members WHERE direction_id=?')->execute([$id]);
+}
+header('Location: directions.php');
+exit();
+?>

--- a/direction_edit.php
+++ b/direction_edit.php
@@ -1,0 +1,37 @@
+<?php
+include 'header.php';
+$id = $_GET['id'] ?? null;
+$direction = ['title'=>'','description'=>''];
+if($id){
+    $stmt = $pdo->prepare('SELECT * FROM research_directions WHERE id=?');
+    $stmt->execute([$id]);
+    $direction = $stmt->fetch();
+}
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $title = $_POST['title'];
+    $description = $_POST['description'];
+    if($id){
+        $stmt = $pdo->prepare('UPDATE research_directions SET title=?, description=? WHERE id=?');
+        $stmt->execute([$title,$description,$id]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO research_directions(title,description) VALUES (?,?)');
+        $stmt->execute([$title,$description]);
+    }
+    header('Location: directions.php');
+    exit();
+}
+?>
+<h2><?= $id? 'Edit':'Add'; ?> Research Direction</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Title</label>
+    <input type="text" name="title" class="form-control" value="<?= htmlspecialchars($direction['title']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($direction['description']); ?></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="directions.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php include 'footer.php'; ?>

--- a/direction_member_add.php
+++ b/direction_member_add.php
@@ -1,0 +1,12 @@
+<?php
+include 'auth.php';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $direction_id = $_POST['direction_id'];
+    $member_id = $_POST['member_id'];
+    $pdo->prepare('INSERT IGNORE INTO direction_members(direction_id,member_id) VALUES (?,?)')->execute([$direction_id,$member_id]);
+    header('Location: direction_members.php?id='.$direction_id);
+    exit();
+}
+header('Location: directions.php');
+exit();
+?>

--- a/direction_member_remove.php
+++ b/direction_member_remove.php
@@ -1,0 +1,10 @@
+<?php
+include 'auth.php';
+$direction_id = $_GET['direction_id'] ?? null;
+$member_id = $_GET['member_id'] ?? null;
+if($direction_id && $member_id){
+    $pdo->prepare('DELETE FROM direction_members WHERE direction_id=? AND member_id=?')->execute([$direction_id,$member_id]);
+}
+header('Location: direction_members.php?id='.$direction_id);
+exit();
+?>

--- a/direction_members.php
+++ b/direction_members.php
@@ -1,0 +1,42 @@
+<?php
+include 'header.php';
+$direction_id = $_GET['id'] ?? null;
+if(!$direction_id){
+    header('Location: directions.php');
+    exit();
+}
+$direction_stmt = $pdo->prepare('SELECT * FROM research_directions WHERE id=?');
+$direction_stmt->execute([$direction_id]);
+$direction = $direction_stmt->fetch();
+$current_stmt = $pdo->prepare('SELECT m.id, m.campus_id, m.name FROM direction_members dm JOIN members m ON dm.member_id=m.id WHERE dm.direction_id=?');
+$current_stmt->execute([$direction_id]);
+$current_members = $current_stmt->fetchAll();
+$members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')->fetchAll();
+?>
+<h2>Direction Members - <?= htmlspecialchars($direction['title']); ?></h2>
+<table class="table table-bordered">
+<tr><th>Campus ID</th><th>Name</th><th>Action</th></tr>
+<?php foreach($current_members as $c): ?>
+<tr>
+  <td><?= htmlspecialchars($c['campus_id']); ?></td>
+  <td><?= htmlspecialchars($c['name']); ?></td>
+  <td><a class="btn btn-sm btn-danger" href="direction_member_remove.php?direction_id=<?= $direction_id; ?>&member_id=<?= $c['id']; ?>" onclick="return doubleConfirm('Remove member from direction?');">Remove</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<h4>Add Member</h4>
+<form method="post" action="direction_member_add.php">
+  <input type="hidden" name="direction_id" value="<?= $direction_id; ?>">
+  <div class="mb-3">
+    <label class="form-label">Member</label>
+    <select name="member_id" class="form-select" required>
+      <option value="">Select member</option>
+      <?php foreach($members as $m): ?>
+      <option value="<?= $m['id']; ?>"><?= htmlspecialchars($m['name']); ?> (<?= $m['campus_id']; ?>)</option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Add</button>
+  <a href="directions.php" class="btn btn-secondary">Back</a>
+</form>
+<?php include 'footer.php'; ?>

--- a/directions.php
+++ b/directions.php
@@ -1,0 +1,23 @@
+<?php include 'header.php';
+$directions = $pdo->query('SELECT * FROM research_directions ORDER BY id DESC')->fetchAll();
+?>
+<div class="d-flex justify-content-between mb-3">
+  <h2>Research Directions</h2>
+  <div>
+    <a class="btn btn-success" href="direction_edit.php">Add Direction</a>
+  </div>
+</div>
+<table class="table table-bordered">
+<tr><th>Title</th><th>Actions</th></tr>
+<?php foreach($directions as $d): ?>
+<tr>
+  <td><?= htmlspecialchars($d['title']); ?></td>
+  <td>
+    <a class="btn btn-sm btn-primary" href="direction_edit.php?id=<?= $d['id']; ?>">Edit</a>
+    <a class="btn btn-sm btn-warning" href="direction_members.php?id=<?= $d['id']; ?>">Members</a>
+    <a class="btn btn-sm btn-danger" href="direction_delete.php?id=<?= $d['id']; ?>" onclick="return doubleConfirm('Delete direction?');">Delete</a>
+  </td>
+</tr>
+<?php endforeach; ?>
+</table>
+<?php include 'footer.php'; ?>

--- a/header.php
+++ b/header.php
@@ -18,6 +18,7 @@
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item"><a class="nav-link" href="members.php" data-i18n="nav.members">Members</a></li>
         <li class="nav-item"><a class="nav-link" href="projects.php" data-i18n="nav.projects">Projects</a></li>
+        <li class="nav-item"><a class="nav-link" href="directions.php">Research Directions</a></li>
         <li class="nav-item"><a class="nav-link" href="tasks.php" data-i18n="nav.tasks">Tasks</a></li>
         <li class="nav-item"><a class="nav-link" href="workload.php" data-i18n="nav.workload">Workload</a></li>
         <li class="nav-item"><a class="nav-link" href="account.php" data-i18n="nav.account">Account</a></li>

--- a/projects.php
+++ b/projects.php
@@ -1,11 +1,11 @@
 <?php include 'header.php';
 $status = $_GET['status'] ?? '';
 if($status){
-    $stmt = $pdo->prepare('SELECT * FROM projects WHERE status=? ORDER BY id DESC');
+    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(m.name SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id WHERE p.status=? GROUP BY p.id ORDER BY p.id DESC');
     $stmt->execute([$status]);
     $projects = $stmt->fetchAll();
 } else {
-    $projects = $pdo->query('SELECT * FROM projects ORDER BY id DESC')->fetchAll();
+    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(m.name SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id GROUP BY p.id ORDER BY p.id DESC')->fetchAll();
 }
 ?>
 <div class="d-flex justify-content-between mb-3">
@@ -29,10 +29,11 @@ if($status){
   </div>
 </form>
 <table class="table table-bordered">
-<tr><th>Title</th><th>Begin</th><th>End</th><th>Status</th><th>Actions</th></tr>
+<tr><th>Title</th><th>Members</th><th>Begin</th><th>End</th><th>Status</th><th>Actions</th></tr>
 <?php foreach($projects as $p): ?>
 <tr>
   <td><?= htmlspecialchars($p['title']); ?></td>
+  <td><?= htmlspecialchars($p['members']); ?></td>
   <td><?= htmlspecialchars($p['begin_date']); ?></td>
   <td><?= htmlspecialchars($p['end_date']); ?></td>
   <td><?= htmlspecialchars($p['status']); ?></td>


### PR DESCRIPTION
## Summary
- Split project and urgent-affair hours in workload reports and export
- Display current project members directly in the project list
- Introduce Research Directions module with member management
- Allow multiple members per urgent affair and update workload calculations

## Testing
- `php -l header.php projects.php workload.php affair_add.php task_affairs.php affair_delete.php directions.php direction_edit.php direction_delete.php direction_members.php direction_member_add.php direction_member_remove.php`


------
https://chatgpt.com/codex/tasks/task_e_6899b75f0a38832a9798e75d8ab93960