### PR TITLE
Support member ordering and public self-update

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -40,6 +40,7 @@ CREATE TABLE project_member_log (
   id INT AUTO_INCREMENT PRIMARY KEY,
   project_id INT NOT NULL,
   member_id INT NOT NULL,
+  sort_order INT DEFAULT 0,
   join_time DATETIME NOT NULL,
   exit_time DATETIME DEFAULT NULL,
   FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
@@ -80,6 +81,7 @@ CREATE TABLE research_directions (
 CREATE TABLE direction_members (
   direction_id INT NOT NULL,
   member_id INT NOT NULL,
+  sort_order INT DEFAULT 0,
   PRIMARY KEY (direction_id, member_id),
   FOREIGN KEY (direction_id) REFERENCES research_directions(id) ON DELETE CASCADE,
   FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE

--- a/direction_member_add.php
+++ b/direction_member_add.php
@@ -3,7 +3,11 @@ include 'auth.php';
 if($_SERVER['REQUEST_METHOD']==='POST'){
     $direction_id = $_POST['direction_id'];
     $member_id = $_POST['member_id'];
-    $pdo->prepare('INSERT IGNORE INTO direction_members(direction_id,member_id) VALUES (?,?)')->execute([$direction_id,$member_id]);
+    $orderStmt = $pdo->prepare('SELECT COALESCE(MAX(sort_order),-1)+1 FROM direction_members WHERE direction_id=?');
+    $orderStmt->execute([$direction_id]);
+    $nextOrder = $orderStmt->fetchColumn();
+    $stmt = $pdo->prepare('INSERT IGNORE INTO direction_members(direction_id,member_id,sort_order) VALUES (?,?,?)');
+    $stmt->execute([$direction_id,$member_id,$nextOrder]);
     header('Location: direction_members.php?id='.$direction_id);
     exit();
 }

--- a/direction_member_order.php
+++ b/direction_member_order.php
@@ -1,0 +1,12 @@
+<?php
+include 'auth.php';
+$data = json_decode(file_get_contents('php://input'), true);
+if(isset($data['direction_id']) && isset($data['order'])){
+    $direction_id = $data['direction_id'];
+    $stmt = $pdo->prepare('UPDATE direction_members SET sort_order=? WHERE direction_id=? AND member_id=?');
+    foreach($data['order'] as $index => $member_id){
+        $stmt->execute([$index, $direction_id, $member_id]);
+    }
+}
+echo json_encode(['status'=>'ok']);
+?>

--- a/direction_members.php
+++ b/direction_members.php
@@ -8,21 +8,24 @@ if(!$direction_id){
 $direction_stmt = $pdo->prepare('SELECT * FROM research_directions WHERE id=?');
 $direction_stmt->execute([$direction_id]);
 $direction = $direction_stmt->fetch();
-$current_stmt = $pdo->prepare('SELECT m.id, m.campus_id, m.name FROM direction_members dm JOIN members m ON dm.member_id=m.id WHERE dm.direction_id=?');
+$current_stmt = $pdo->prepare('SELECT m.id, m.campus_id, m.name FROM direction_members dm JOIN members m ON dm.member_id=m.id WHERE dm.direction_id=? ORDER BY dm.sort_order');
 $current_stmt->execute([$direction_id]);
 $current_members = $current_stmt->fetchAll();
 $members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')->fetchAll();
 ?>
 <h2>Direction Members - <?= htmlspecialchars($direction['title']); ?></h2>
 <table class="table table-bordered">
-<tr><th>Campus ID</th><th>Name</th><th>Action</th></tr>
+<tr><th></th><th>Campus ID</th><th>Name</th><th>Action</th></tr>
+<tbody id="memberList">
 <?php foreach($current_members as $c): ?>
-<tr>
+<tr data-id="<?= $c['id']; ?>">
+  <td class="drag-handle">&#9776;</td>
   <td><?= htmlspecialchars($c['campus_id']); ?></td>
   <td><?= htmlspecialchars($c['name']); ?></td>
   <td><a class="btn btn-sm btn-danger" href="direction_member_remove.php?direction_id=<?= $direction_id; ?>&member_id=<?= $c['id']; ?>" onclick="return doubleConfirm('Remove member from direction?');">Remove</a></td>
 </tr>
 <?php endforeach; ?>
+</tbody>
 </table>
 <h4>Add Member</h4>
 <form method="post" action="direction_member_add.php">
@@ -31,7 +34,7 @@ $members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')-
     <label class="form-label">Member</label>
     <select name="member_id" class="form-select" required>
       <option value="">Select member</option>
-      <?php foreach($members as $m): ?>
+<?php foreach($members as $m): ?>
       <option value="<?= $m['id']; ?>"><?= htmlspecialchars($m['name']); ?> (<?= $m['campus_id']; ?>)</option>
       <?php endforeach; ?>
     </select>
@@ -39,4 +42,21 @@ $members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')-
   <button type="submit" class="btn btn-primary">Add</button>
   <a href="directions.php" class="btn btn-secondary">Back</a>
 </form>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  Sortable.create(document.getElementById('memberList'), {
+    handle: '.drag-handle',
+    animation: 150,
+    onEnd: function() {
+      const order = Array.from(document.querySelectorAll('#memberList tr')).map((row, index) => row.dataset.id);
+      fetch('direction_member_order.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({direction_id: <?= $direction_id; ?>, order: order})
+      });
+    }
+  });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/member_self_update.php
+++ b/member_self_update.php
@@ -1,0 +1,130 @@
+<?php
+require 'config.php';
+$member_id = $_SESSION['self_update_member_id'] ?? null;
+$member = null;
+$error = '';
+$msg = '';
+
+if(isset($_POST['action']) && $_POST['action'] === 'verify'){
+    $name = $_POST['name'];
+    $identity = $_POST['identity_number'];
+    $stmt = $pdo->prepare('SELECT * FROM members WHERE name=? AND identity_number=?');
+    $stmt->execute([$name, $identity]);
+    $member = $stmt->fetch();
+    if($member){
+        $_SESSION['self_update_member_id'] = $member['id'];
+        $member_id = $member['id'];
+    } else {
+        $error = 'No matching member found.';
+    }
+}
+
+if($member_id){
+    if(!$member){
+        $stmt = $pdo->prepare('SELECT * FROM members WHERE id=?');
+        $stmt->execute([$member_id]);
+        $member = $stmt->fetch();
+    }
+    if(isset($_POST['action']) && $_POST['action'] === 'update'){
+        $campus_id = $_POST['campus_id'];
+        $name = $_POST['name'];
+        $email = $_POST['email'];
+        $identity_number = $_POST['identity_number'];
+        $year_of_join = $_POST['year_of_join'];
+        $current_degree = $_POST['current_degree'];
+        $degree_pursuing = $_POST['degree_pursuing'];
+        $phone = $_POST['phone'];
+        $wechat = $_POST['wechat'];
+        $department = $_POST['department'];
+        $workplace = $_POST['workplace'];
+        $homeplace = $_POST['homeplace'];
+        $stmt = $pdo->prepare('UPDATE members SET campus_id=?, name=?, email=?, identity_number=?, year_of_join=?, current_degree=?, degree_pursuing=?, phone=?, wechat=?, department=?, workplace=?, homeplace=? WHERE id=?');
+        $stmt->execute([$campus_id,$name,$email,$identity_number,$year_of_join,$current_degree,$degree_pursuing,$phone,$wechat,$department,$workplace,$homeplace,$member_id]);
+        $msg = 'Information updated successfully.';
+        $stmt = $pdo->prepare('SELECT * FROM members WHERE id=?');
+        $stmt->execute([$member_id]);
+        $member = $stmt->fetch();
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Member Update</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-5">
+<h2>Member Information Update</h2>
+<?php if(!$member_id): ?>
+<form method="post" class="mt-4">
+  <input type="hidden" name="action" value="verify">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Identity Number</label>
+    <input type="text" name="identity_number" class="form-control" required>
+  </div>
+  <?php if($error): ?><div class="text-danger mb-3"><?= $error; ?></div><?php endif; ?>
+  <button type="submit" class="btn btn-primary">Verify</button>
+</form>
+<?php else: ?>
+<?php if($msg): ?><div class="alert alert-success mt-3"><?= $msg; ?></div><?php endif; ?>
+<form method="post" class="mt-4">
+  <input type="hidden" name="action" value="update">
+  <div class="mb-3">
+    <label class="form-label">Campus ID</label>
+    <input type="text" name="campus_id" class="form-control" value="<?= htmlspecialchars($member['campus_id']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($member['name']); ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Email</label>
+    <input type="email" name="email" class="form-control" value="<?= htmlspecialchars($member['email']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Identity Number</label>
+    <input type="text" name="identity_number" class="form-control" value="<?= htmlspecialchars($member['identity_number']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Year of Join</label>
+    <input type="number" name="year_of_join" class="form-control" value="<?= htmlspecialchars($member['year_of_join']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Current Degree</label>
+    <input type="text" name="current_degree" class="form-control" value="<?= htmlspecialchars($member['current_degree']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Degree Pursuing</label>
+    <input type="text" name="degree_pursuing" class="form-control" value="<?= htmlspecialchars($member['degree_pursuing']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Phone</label>
+    <input type="text" name="phone" class="form-control" value="<?= htmlspecialchars($member['phone']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">WeChat</label>
+    <input type="text" name="wechat" class="form-control" value="<?= htmlspecialchars($member['wechat']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Department</label>
+    <input type="text" name="department" class="form-control" value="<?= htmlspecialchars($member['department']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Workplace</label>
+    <input type="text" name="workplace" class="form-control" value="<?= htmlspecialchars($member['workplace']); ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Homeplace</label>
+    <input type="text" name="homeplace" class="form-control" value="<?= htmlspecialchars($member['homeplace']); ?>">
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+<?php endif; ?>
+</body>
+</html>

--- a/members.php
+++ b/members.php
@@ -32,6 +32,7 @@ $members = $stmt->fetchAll();
     <a class="btn btn-success" href="member_edit.php">Add Member</a>
     <a class="btn btn-secondary" href="members_import.php">Import Excel</a>
     <a class="btn btn-secondary" href="members_export.php">Export Excel</a>
+    <a class="btn btn-warning" href="member_self_update.php">Ask for Update</a>
   </div>
 </div>
 <div class="table-responsive">

--- a/project_member_add.php
+++ b/project_member_add.php
@@ -4,8 +4,11 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     $project_id = $_POST['project_id'];
     $member_id = $_POST['member_id'];
     $join_time = $_POST['join_time'];
-    $stmt = $pdo->prepare('INSERT INTO project_member_log(project_id,member_id,join_time) VALUES (?,?,?)');
-    $stmt->execute([$project_id,$member_id,$join_time]);
+    $orderStmt = $pdo->prepare('SELECT COALESCE(MAX(sort_order),-1)+1 FROM project_member_log WHERE project_id=? AND exit_time IS NULL');
+    $orderStmt->execute([$project_id]);
+    $nextOrder = $orderStmt->fetchColumn();
+    $stmt = $pdo->prepare('INSERT INTO project_member_log(project_id,member_id,join_time,sort_order) VALUES (?,?,?,?)');
+    $stmt->execute([$project_id,$member_id,$join_time,$nextOrder]);
     header('Location: project_members.php?id='.$project_id);
     exit();
 }

--- a/project_member_order.php
+++ b/project_member_order.php
@@ -1,0 +1,11 @@
+<?php
+include 'auth.php';
+$data = json_decode(file_get_contents('php://input'), true);
+if(isset($data['order'])){
+    $stmt = $pdo->prepare('UPDATE project_member_log SET sort_order=? WHERE id=?');
+    foreach($data['order'] as $item){
+        $stmt->execute([$item['position'], $item['id']]);
+    }
+}
+echo json_encode(['status'=>'ok']);
+?>

--- a/update_db.sql
+++ b/update_db.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project_member_log ADD COLUMN sort_order INT DEFAULT 0;
+ALTER TABLE direction_members ADD COLUMN sort_order INT DEFAULT 0;


### PR DESCRIPTION
## Summary
- Allow managers to reorder project and research direction members via drag-and-drop
- Store member display order with new `sort_order` fields and provide SQL migration
- Add public self-update page where members verify their name and ID to edit their profile

## Testing
- `php -l project_members.php`
- `php -l direction_members.php`
- `php -l project_member_order.php`
- `php -l direction_member_order.php`
- `php -l member_self_update.php`

------
https://chatgpt.com/codex/tasks/task_e_689a946115bc832a821b32ff40c93f8d