### PR TITLE
Support ordering and assignment overview

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -13,6 +13,7 @@ INSERT INTO managers (username,password) VALUES
 
 CREATE TABLE members (
   id INT AUTO_INCREMENT PRIMARY KEY,
+  sort_order INT DEFAULT 0,
   campus_id VARCHAR(20) UNIQUE NOT NULL,
   name VARCHAR(100) NOT NULL,
   email VARCHAR(100),
@@ -29,6 +30,7 @@ CREATE TABLE members (
 
 CREATE TABLE projects (
   id INT AUTO_INCREMENT PRIMARY KEY,
+  sort_order INT DEFAULT 0,
   title VARCHAR(100) NOT NULL,
   description TEXT,
   begin_date DATE,
@@ -74,6 +76,7 @@ CREATE TABLE task_affair_members (
 
 CREATE TABLE research_directions (
   id INT AUTO_INCREMENT PRIMARY KEY,
+  sort_order INT DEFAULT 0,
   title VARCHAR(100) NOT NULL,
   description TEXT
 );

--- a/direction_edit.php
+++ b/direction_edit.php
@@ -14,8 +14,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
         $stmt = $pdo->prepare('UPDATE research_directions SET title=?, description=? WHERE id=?');
         $stmt->execute([$title,$description,$id]);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO research_directions(title,description) VALUES (?,?)');
-        $stmt->execute([$title,$description]);
+        $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM research_directions');
+        $nextOrder = $orderStmt->fetchColumn();
+        $stmt = $pdo->prepare('INSERT INTO research_directions(title,description,sort_order) VALUES (?,?,?)');
+        $stmt->execute([$title,$description,$nextOrder]);
     }
     header('Location: directions.php');
     exit();

--- a/direction_order.php
+++ b/direction_order.php
@@ -1,0 +1,11 @@
+<?php
+include 'auth.php';
+$data = json_decode(file_get_contents('php://input'), true);
+if(isset($data['order'])){
+    $stmt = $pdo->prepare('UPDATE research_directions SET sort_order=? WHERE id=?');
+    foreach($data['order'] as $item){
+        $stmt->execute([$item['position'], $item['id']]);
+    }
+}
+echo json_encode(['status'=>'ok']);
+?>

--- a/directions.php
+++ b/directions.php
@@ -5,7 +5,7 @@ $stmt = $pdo->query("SELECT d.*, GROUP_CONCAT(m.name ORDER BY dm.sort_order SEPA
                      LEFT JOIN direction_members dm ON d.id = dm.direction_id
                      LEFT JOIN members m ON dm.member_id = m.id
                      GROUP BY d.id
-                     ORDER BY d.id DESC");
+                     ORDER BY d.sort_order");
 $directions = $stmt->fetchAll();
 ?>
 <div class="d-flex justify-content-between mb-3">
@@ -15,21 +15,56 @@ $directions = $stmt->fetchAll();
   </div>
 </div>
 <table class="table table-bordered">
-<tr>
-  <th data-i18n="directions.table_title">Title</th>
-  <th data-i18n="directions.table_members">Members</th>
-  <th data-i18n="directions.table_actions">Actions</th>
-</tr>
-<?php foreach($directions as $d): ?>
-<tr>
-  <td><?= htmlspecialchars($d['title']); ?></td>
-  <td><?= $d['member_names'] ? htmlspecialchars($d['member_names']) : '<em data-i18n="directions.none">None</em>'; ?></td>
-  <td>
-    <a class="btn btn-sm btn-primary" href="direction_edit.php?id=<?= $d['id']; ?>" data-i18n="directions.action_edit">Edit</a>
-    <a class="btn btn-sm btn-warning" href="direction_members.php?id=<?= $d['id']; ?>" data-i18n="directions.action_members">Members</a>
-    <a class="btn btn-sm btn-danger" href="direction_delete.php?id=<?= $d['id']; ?>" onclick="return doubleConfirm('Delete direction?');" data-i18n="directions.action_delete">Delete</a>
-  </td>
-</tr>
-<?php endforeach; ?>
+  <thead>
+  <tr>
+    <th></th>
+    <th data-i18n="directions.table_title">Title</th>
+    <th data-i18n="directions.table_members">Members</th>
+    <th data-i18n="directions.table_actions">Actions</th>
+  </tr>
+  </thead>
+  <tbody id="directionList">
+  <?php foreach($directions as $d): ?>
+  <tr data-id="<?= $d['id']; ?>">
+    <td class="drag-handle">&#9776;</td>
+    <td><?= htmlspecialchars($d['title']); ?></td>
+    <td><?= $d['member_names'] ? htmlspecialchars($d['member_names']) : '<em data-i18n="directions.none">None</em>'; ?></td>
+    <td>
+      <a class="btn btn-sm btn-primary" href="direction_edit.php?id=<?= $d['id']; ?>" data-i18n="directions.action_edit">Edit</a>
+      <a class="btn btn-sm btn-warning" href="direction_members.php?id=<?= $d['id']; ?>" data-i18n="directions.action_members">Members</a>
+      <a class="btn btn-sm btn-danger" href="direction_delete.php?id=<?= $d['id']; ?>" onclick="return doubleConfirm('Delete direction?');" data-i18n="directions.action_delete">Delete</a>
+    </td>
+  </tr>
+  <?php endforeach; ?>
+  </tbody>
 </table>
+<h3 class="mt-4">Member Direction Assignments</h3>
+<table class="table table-bordered">
+  <tr><th>Member</th><th>Research Directions</th></tr>
+  <?php
+  $memberDirs = $pdo->query('SELECT m.name, GROUP_CONCAT(d.title ORDER BY dm.sort_order SEPARATOR ", ") AS dirs FROM members m LEFT JOIN direction_members dm ON m.id=dm.member_id LEFT JOIN research_directions d ON dm.direction_id=d.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
+  foreach($memberDirs as $md): ?>
+  <tr>
+    <td><?= htmlspecialchars($md["name"]); ?></td>
+    <td><?= $md['dirs'] ? htmlspecialchars($md['dirs']) : '<em>None</em>'; ?></td>
+  </tr>
+  <?php endforeach; ?>
+</table>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  Sortable.create(document.getElementById('directionList'), {
+    handle: '.drag-handle',
+    animation: 150,
+    onEnd: function(){
+      const order = Array.from(document.querySelectorAll('#directionList tr')).map((row, index) => ({id: row.dataset.id, position: index}));
+      fetch('direction_order.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({order: order})
+      });
+    }
+  });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/member_edit.php
+++ b/member_edit.php
@@ -24,8 +24,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
         $stmt = $pdo->prepare('UPDATE members SET campus_id=?, name=?, email=?, identity_number=?, year_of_join=?, current_degree=?, degree_pursuing=?, phone=?, wechat=?, department=?, workplace=?, homeplace=? WHERE id=?');
         $stmt->execute([$campus_id,$name,$email,$identity_number,$year_of_join,$current_degree,$degree_pursuing,$phone,$wechat,$department,$workplace,$homeplace,$id]);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO members(campus_id,name,email,identity_number,year_of_join,current_degree,degree_pursuing,phone,wechat,department,workplace,homeplace) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
-        $stmt->execute([$campus_id,$name,$email,$identity_number,$year_of_join,$current_degree,$degree_pursuing,$phone,$wechat,$department,$workplace,$homeplace]);
+        $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM members');
+        $nextOrder = $orderStmt->fetchColumn();
+        $stmt = $pdo->prepare('INSERT INTO members(campus_id,name,email,identity_number,year_of_join,current_degree,degree_pursuing,phone,wechat,department,workplace,homeplace,sort_order) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)');
+        $stmt->execute([$campus_id,$name,$email,$identity_number,$year_of_join,$current_degree,$degree_pursuing,$phone,$wechat,$department,$workplace,$homeplace,$nextOrder]);
     }
     header('Location: members.php');
     exit();

--- a/member_order.php
+++ b/member_order.php
@@ -1,0 +1,11 @@
+<?php
+include 'auth.php';
+$data = json_decode(file_get_contents('php://input'), true);
+if(isset($data['order'])){
+    $stmt = $pdo->prepare('UPDATE members SET sort_order=? WHERE id=?');
+    foreach($data['order'] as $item){
+        $stmt->execute([$item['position'], $item['id']]);
+    }
+}
+echo json_encode(['status'=>'ok']);
+?>

--- a/member_self_update.php
+++ b/member_self_update.php
@@ -4,6 +4,8 @@ $member_id = $_SESSION['self_update_member_id'] ?? null;
 $member = null;
 $error = '';
 $msg = '';
+$current_projects = [];
+$current_directions = [];
 
 if(isset($_POST['action']) && $_POST['action'] === 'verify'){
     $name = $_POST['name'];
@@ -45,6 +47,12 @@ if($member_id){
         $stmt->execute([$member_id]);
         $member = $stmt->fetch();
     }
+    $projStmt = $pdo->prepare('SELECT p.title FROM project_member_log l JOIN projects p ON l.project_id=p.id WHERE l.member_id=? AND l.exit_time IS NULL ORDER BY l.sort_order');
+    $projStmt->execute([$member_id]);
+    $current_projects = $projStmt->fetchAll(PDO::FETCH_COLUMN);
+    $dirStmt = $pdo->prepare('SELECT d.title FROM direction_members dm JOIN research_directions d ON dm.direction_id=d.id WHERE dm.member_id=? ORDER BY dm.sort_order');
+    $dirStmt->execute([$member_id]);
+    $current_directions = $dirStmt->fetchAll(PDO::FETCH_COLUMN);
 }
 ?>
 <!DOCTYPE html>
@@ -125,6 +133,22 @@ if($member_id){
   </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
+<h4 class="mt-5">Current Projects</h4>
+<ul>
+  <?php if($current_projects): foreach($current_projects as $p): ?>
+    <li><?= htmlspecialchars($p); ?></li>
+  <?php endforeach; else: ?>
+    <li><em>None</em></li>
+  <?php endif; ?>
+</ul>
+<h4>Research Directions</h4>
+<ul>
+  <?php if($current_directions): foreach($current_directions as $d): ?>
+    <li><?= htmlspecialchars($d); ?></li>
+  <?php endforeach; else: ?>
+    <li><em>None</em></li>
+  <?php endif; ?>
+</ul>
 <?php endif; ?>
 </body>
 </html>

--- a/members.php
+++ b/members.php
@@ -17,9 +17,9 @@ $columns = [
     'homeplace' => 'Homeplace'
 ];
 
-$sort = $_GET['sort'] ?? 'id';
-if (!array_key_exists($sort, $columns) && $sort !== 'id') {
-    $sort = 'id';
+$sort = $_GET['sort'] ?? 'sort_order';
+if (!array_key_exists($sort, $columns) && $sort !== 'sort_order') {
+    $sort = 'sort_order';
 }
 $dir = strtolower($_GET['dir'] ?? 'asc') === 'desc' ? 'DESC' : 'ASC';
 
@@ -37,7 +37,9 @@ $members = $stmt->fetchAll();
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped table-hover">
+  <thead>
   <tr>
+    <th></th>
     <?php foreach($columns as $col => $label):
         $newDir = ($sort === $col && $dir === 'ASC') ? 'desc' : 'asc';
     ?>
@@ -45,8 +47,11 @@ $members = $stmt->fetchAll();
     <?php endforeach; ?>
     <th>Actions</th>
   </tr>
+  </thead>
+  <tbody id="memberList">
   <?php foreach($members as $m): ?>
-  <tr>
+  <tr data-id="<?= $m['id']; ?>">
+    <td class="drag-handle">&#9776;</td>
     <td><?= htmlspecialchars($m['campus_id']); ?></td>
     <td><?= htmlspecialchars($m['name']); ?></td>
     <td><?= htmlspecialchars($m['email']); ?></td>
@@ -65,6 +70,24 @@ $members = $stmt->fetchAll();
     </td>
   </tr>
   <?php endforeach; ?>
+  </tbody>
 </table>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  Sortable.create(document.getElementById('memberList'), {
+    handle: '.drag-handle',
+    animation: 150,
+    onEnd: function(){
+      const order = Array.from(document.querySelectorAll('#memberList tr')).map((row, index) => ({id: row.dataset.id, position: index}));
+      fetch('member_order.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({order: order})
+      });
+    }
+  });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/project_edit.php
+++ b/project_edit.php
@@ -17,8 +17,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
         $stmt = $pdo->prepare('UPDATE projects SET title=?, description=?, begin_date=?, end_date=?, status=? WHERE id=?');
         $stmt->execute([$title,$description,$begin_date,$end_date,$status,$id]);
     } else {
-        $stmt = $pdo->prepare('INSERT INTO projects(title,description,begin_date,end_date,status) VALUES (?,?,?,?,?)');
-        $stmt->execute([$title,$description,$begin_date,$end_date,$status]);
+        $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM projects');
+        $nextOrder = $orderStmt->fetchColumn();
+        $stmt = $pdo->prepare('INSERT INTO projects(title,description,begin_date,end_date,status,sort_order) VALUES (?,?,?,?,?,?)');
+        $stmt->execute([$title,$description,$begin_date,$end_date,$status,$nextOrder]);
     }
     header('Location: projects.php');
     exit();

--- a/project_order.php
+++ b/project_order.php
@@ -1,0 +1,11 @@
+<?php
+include 'auth.php';
+$data = json_decode(file_get_contents('php://input'), true);
+if(isset($data['order'])){
+    $stmt = $pdo->prepare('UPDATE projects SET sort_order=? WHERE id=?');
+    foreach($data['order'] as $item){
+        $stmt->execute([$item['position'], $item['id']]);
+    }
+}
+echo json_encode(['status'=>'ok']);
+?>

--- a/projects.php
+++ b/projects.php
@@ -1,11 +1,11 @@
 <?php include 'header.php';
 $status = $_GET['status'] ?? '';
 if($status){
-    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(m.name ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id WHERE p.status=? GROUP BY p.id ORDER BY p.id DESC');
+    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(m.name ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
     $stmt->execute([$status]);
     $projects = $stmt->fetchAll();
 } else {
-    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(m.name ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id GROUP BY p.id ORDER BY p.id DESC')->fetchAll();
+    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(m.name ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
 }
 ?>
 <div class="d-flex justify-content-between mb-3">
@@ -29,27 +29,62 @@ if($status){
   </div>
 </form>
 <table class="table table-bordered">
-<tr>
-  <th data-i18n="projects.table_title">Title</th>
-  <th data-i18n="projects.table_members">Members</th>
-  <th data-i18n="projects.table_begin">Begin</th>
-  <th data-i18n="projects.table_end">End</th>
-  <th data-i18n="projects.table_status">Status</th>
-  <th data-i18n="projects.table_actions">Actions</th>
-</tr>
-<?php foreach($projects as $p): ?>
-<tr>
-  <td><?= htmlspecialchars($p['title']); ?></td>
-  <td><?= htmlspecialchars($p['members']); ?></td>
-  <td><?= htmlspecialchars($p['begin_date']); ?></td>
-  <td><?= htmlspecialchars($p['end_date']); ?></td>
-  <td><?= htmlspecialchars($p['status']); ?></td>
-  <td>
-    <a class="btn btn-sm btn-primary" href="project_edit.php?id=<?= $p['id']; ?>" data-i18n="projects.action_edit">Edit</a>
-    <a class="btn btn-sm btn-warning" href="project_members.php?id=<?= $p['id']; ?>" data-i18n="projects.action_members">Members</a>
-    <a class="btn btn-sm btn-danger" href="project_delete.php?id=<?= $p['id']; ?>" onclick="return doubleConfirm('Delete project?');" data-i18n="projects.action_delete">Delete</a>
-  </td>
-</tr>
-<?php endforeach; ?>
+  <thead>
+  <tr>
+    <th></th>
+    <th data-i18n="projects.table_title">Title</th>
+    <th data-i18n="projects.table_members">Members</th>
+    <th data-i18n="projects.table_begin">Begin</th>
+    <th data-i18n="projects.table_end">End</th>
+    <th data-i18n="projects.table_status">Status</th>
+    <th data-i18n="projects.table_actions">Actions</th>
+  </tr>
+  </thead>
+  <tbody id="projectList">
+  <?php foreach($projects as $p): ?>
+  <tr data-id="<?= $p['id']; ?>">
+    <td class="drag-handle">&#9776;</td>
+    <td><?= htmlspecialchars($p['title']); ?></td>
+    <td><?= htmlspecialchars($p['members']); ?></td>
+    <td><?= htmlspecialchars($p['begin_date']); ?></td>
+    <td><?= htmlspecialchars($p['end_date']); ?></td>
+    <td><?= htmlspecialchars($p['status']); ?></td>
+    <td>
+      <a class="btn btn-sm btn-primary" href="project_edit.php?id=<?= $p['id']; ?>" data-i18n="projects.action_edit">Edit</a>
+      <a class="btn btn-sm btn-warning" href="project_members.php?id=<?= $p['id']; ?>" data-i18n="projects.action_members">Members</a>
+      <a class="btn btn-sm btn-danger" href="project_delete.php?id=<?= $p['id']; ?>" onclick="return doubleConfirm('Delete project?');" data-i18n="projects.action_delete">Delete</a>
+    </td>
+  </tr>
+  <?php endforeach; ?>
+  </tbody>
 </table>
+<h3 class="mt-4">Member Project Assignments</h3>
+<table class="table table-bordered">
+  <tr><th>Member</th><th>Projects</th></tr>
+  <?php
+  $memberProjects = $pdo->query('SELECT m.name, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ", ") AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
+  foreach($memberProjects as $mp): ?>
+  <tr>
+    <td><?= htmlspecialchars($mp["name"]); ?></td>
+    <td><?= $mp['proj'] ? htmlspecialchars($mp['proj']) : '<em>None</em>'; ?></td>
+  </tr>
+  <?php endforeach; ?>
+</table>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function(){
+  Sortable.create(document.getElementById('projectList'), {
+    handle: '.drag-handle',
+    animation: 150,
+    onEnd: function(){
+      const order = Array.from(document.querySelectorAll('#projectList tr')).map((row, index) => ({id: row.dataset.id, position: index}));
+      fetch('project_order.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({order: order})
+      });
+    }
+  });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/updated_db.sql
+++ b/updated_db.sql
@@ -1,0 +1,6 @@
+ALTER TABLE members ADD COLUMN sort_order INT DEFAULT 0;
+UPDATE members SET sort_order=id;
+ALTER TABLE projects ADD COLUMN sort_order INT DEFAULT 0;
+UPDATE projects SET sort_order=id;
+ALTER TABLE research_directions ADD COLUMN sort_order INT DEFAULT 0;
+UPDATE research_directions SET sort_order=id;


### PR DESCRIPTION
## Summary
- allow drag-and-drop ordering for members, projects, and research directions
- show which projects and directions each member is assigned to
- store ordering data in new `sort_order` columns and provide DB upgrade script

## Testing
- `php -l members.php projects.php directions.php member_self_update.php member_edit.php project_edit.php direction_edit.php member_order.php project_order.php direction_order.php`

------
https://chatgpt.com/codex/tasks/task_e_689ac6e9d3e8832a9b4539390dcbf52c