### PR TITLE
Display member degree and join year in project and direction lists

### DIFF
--- a/directions.php
+++ b/directions.php
@@ -1,6 +1,6 @@
 <?php include 'header.php';
-// Fetch research directions along with their members' names
-$stmt = $pdo->query("SELECT d.*, GROUP_CONCAT(m.name ORDER BY dm.sort_order SEPARATOR ', ') AS member_names
+// Fetch research directions along with their members' details
+$stmt = $pdo->query("SELECT d.*, GROUP_CONCAT(CONCAT(m.name, '(', COALESCE(m.degree_pursuing, ''), ',', COALESCE(m.year_of_join, ''), ')') ORDER BY dm.sort_order SEPARATOR ', ') AS member_names
                      FROM research_directions d
                      LEFT JOIN direction_members dm ON d.id = dm.direction_id
                      LEFT JOIN members m ON dm.member_id = m.id
@@ -28,7 +28,7 @@ $directions = $stmt->fetchAll();
   <tr data-id="<?= $d['id']; ?>">
     <td class="drag-handle">&#9776;</td>
     <td><?= htmlspecialchars($d['title']); ?></td>
-    <td><?= $d['member_names'] ? htmlspecialchars($d['member_names']) : '<em data-i18n="directions.none">None</em>'; ?></td>
+    <td><?= $d['member_names'] ? preg_replace('/\([^()]*\)/', '<span style="color:#cccccc;">$0</span>', htmlspecialchars($d['member_names'])) : '<em data-i18n="directions.none">None</em>'; ?></td>
     <td>
       <a class="btn btn-sm btn-primary" href="direction_edit.php?id=<?= $d['id']; ?>" data-i18n="directions.action_edit">Edit</a>
       <a class="btn btn-sm btn-warning" href="direction_members.php?id=<?= $d['id']; ?>" data-i18n="directions.action_members">Members</a>
@@ -42,10 +42,10 @@ $directions = $stmt->fetchAll();
 <table class="table table-bordered">
   <tr><th>Member</th><th>Research Directions</th></tr>
   <?php
-  $memberDirs = $pdo->query('SELECT m.name, GROUP_CONCAT(d.title ORDER BY dm.sort_order SEPARATOR ", ") AS dirs FROM members m LEFT JOIN direction_members dm ON m.id=dm.member_id LEFT JOIN research_directions d ON dm.direction_id=d.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
+  $memberDirs = $pdo->query('SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(d.title ORDER BY dm.sort_order SEPARATOR ", ") AS dirs FROM members m LEFT JOIN direction_members dm ON m.id=dm.member_id LEFT JOIN research_directions d ON dm.direction_id=d.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
   foreach($memberDirs as $md): ?>
   <tr>
-    <td><?= htmlspecialchars($md["name"]); ?></td>
+    <td><?= htmlspecialchars($md["name"]); ?><span style="color:#cccccc;">(<?= htmlspecialchars($md["degree_pursuing"]); ?>,<?= htmlspecialchars($md["year_of_join"]); ?>)</span></td>
     <td><?= $md['dirs'] ? htmlspecialchars($md['dirs']) : '<em>None</em>'; ?></td>
   </tr>
   <?php endforeach; ?>

--- a/projects.php
+++ b/projects.php
@@ -1,11 +1,11 @@
 <?php include 'header.php';
 $status = $_GET['status'] ?? '';
 if($status){
-    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(m.name ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
+    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
     $stmt->execute([$status]);
     $projects = $stmt->fetchAll();
 } else {
-    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(m.name ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
+    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
 }
 ?>
 <div class="d-flex justify-content-between mb-3">
@@ -45,7 +45,7 @@ if($status){
   <tr data-id="<?= $p['id']; ?>">
     <td class="drag-handle">&#9776;</td>
     <td><?= htmlspecialchars($p['title']); ?></td>
-    <td><?= htmlspecialchars($p['members']); ?></td>
+    <td><?= preg_replace('/\([^()]*\)/', '<span style="color:#cccccc;">$0</span>', htmlspecialchars($p['members'])); ?></td>
     <td><?= htmlspecialchars($p['begin_date']); ?></td>
     <td><?= htmlspecialchars($p['end_date']); ?></td>
     <td><?= htmlspecialchars($p['status']); ?></td>
@@ -62,10 +62,10 @@ if($status){
 <table class="table table-bordered">
   <tr><th>Member</th><th>Projects</th></tr>
   <?php
-  $memberProjects = $pdo->query('SELECT m.name, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ", ") AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
+  $memberProjects = $pdo->query('SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ", ") AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
   foreach($memberProjects as $mp): ?>
   <tr>
-    <td><?= htmlspecialchars($mp["name"]); ?></td>
+    <td><?= htmlspecialchars($mp["name"]); ?><span style="color:#cccccc;">(<?= htmlspecialchars($mp["degree_pursuing"]); ?>,<?= htmlspecialchars($mp["year_of_join"]); ?>)</span></td>
     <td><?= $mp['proj'] ? htmlspecialchars($mp['proj']) : '<em>None</em>'; ?></td>
   </tr>
   <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Show each member's degree and join year in project listings and member-to-project assignment table, with the details greyed out for readability
- Include member degree and join year in research direction listings and member-to-direction assignments using the same grey styling

## Testing
- `php -l projects.php`
- `php -l directions.php`


------
https://chatgpt.com/codex/tasks/task_e_689adaf58330832a9791fd6cd8c62db8