### PR TITLE
Broaden layout and add member urgent affair portal

### DIFF
--- a/header.php
+++ b/header.php
@@ -6,6 +6,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>团队管理平台</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  .container { max-width: 80%; }
+</style>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">

--- a/login.php
+++ b/login.php
@@ -28,6 +28,9 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title data-i18n="login.title">Manager Login</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  .container { max-width: 80%; }
+</style>
 </head>
 <body>
 <div class="container mt-5">

--- a/member_self_update.php
+++ b/member_self_update.php
@@ -62,6 +62,9 @@ if($member_id){
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>团队成员信息更新</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  .container { max-width: 80%; }
+</style>
 </head>
 <body class="container py-5">
 <h2>团队成员信息更新</h2>

--- a/task_member_fill.php
+++ b/task_member_fill.php
@@ -1,0 +1,105 @@
+<?php
+require 'config.php';
+$task_id = $_GET['task_id'] ?? null;
+if(!$task_id){
+    echo 'Invalid task id';
+    exit();
+}
+if(isset($_SESSION['fill_task_id']) && $_SESSION['fill_task_id'] != $task_id){
+    unset($_SESSION['fill_task_id'], $_SESSION['fill_member_id']);
+}
+$member_id = $_SESSION['fill_member_id'] ?? null;
+$error = '';
+$msg = '';
+if(!$member_id && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['action'] === 'verify'){
+    $name = $_POST['name'] ?? '';
+    $identity = $_POST['identity_number'] ?? '';
+    $stmt = $pdo->prepare('SELECT id FROM members WHERE name=? AND identity_number=?');
+    $stmt->execute([$name,$identity]);
+    $member = $stmt->fetch();
+    if($member){
+        $_SESSION['fill_member_id'] = $member['id'];
+        $_SESSION['fill_task_id'] = $task_id;
+        $member_id = $member['id'];
+    } else {
+        $error = '身份验证失败';
+    }
+}
+if($member_id && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['action'] === 'add'){
+    $description = $_POST['description'];
+    $start_time = $_POST['start_time'];
+    $end_time = $_POST['end_time'];
+    $stmt = $pdo->prepare('INSERT INTO task_affairs(task_id,description,start_time,end_time) VALUES (?,?,?,?)');
+    $stmt->execute([$task_id,$description,$start_time,$end_time]);
+    $affair_id = $pdo->lastInsertId();
+    $pdo->prepare('INSERT INTO task_affair_members(affair_id,member_id) VALUES (?,?)')->execute([$affair_id,$member_id]);
+    $msg = '已提交';
+}
+$affairs = [];
+if($member_id){
+    $stmt = $pdo->prepare('SELECT a.description,a.start_time,a.end_time,GROUP_CONCAT(m.name SEPARATOR ", ") AS members FROM task_affairs a LEFT JOIN task_affair_members am ON a.id=am.affair_id LEFT JOIN members m ON am.member_id=m.id WHERE a.task_id=? GROUP BY a.id ORDER BY a.start_time DESC');
+    $stmt->execute([$task_id]);
+    $affairs = $stmt->fetchAll();
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>紧急事务填写</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+<style>
+  .container { max-width: 80%; }
+</style>
+</head>
+<body class="container py-5">
+<h2>紧急事务填写</h2>
+<?php if(!$member_id): ?>
+<form method="post" class="mt-4">
+  <input type="hidden" name="action" value="verify">
+  <div class="mb-3">
+    <label class="form-label">姓名</label>
+    <input type="text" name="name" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">身份证号码</label>
+    <input type="text" name="identity_number" class="form-control" required>
+  </div>
+  <?php if($error): ?><div class="text-danger mb-3"><?php echo htmlspecialchars($error); ?></div><?php endif; ?>
+  <button type="submit" class="btn btn-primary">验证</button>
+</form>
+<?php else: ?>
+<?php if($msg): ?><div class="alert alert-success"><?php echo htmlspecialchars($msg); ?></div><?php endif; ?>
+<h4>已有紧急事务</h4>
+<table class="table table-bordered">
+<tr><th>描述</th><th>负责成员</th><th>起始时间</th><th>结束时间</th></tr>
+<?php foreach($affairs as $a): ?>
+<tr>
+  <td><?= htmlspecialchars($a['description']); ?></td>
+  <td><?= htmlspecialchars($a['members']); ?></td>
+  <td><?= htmlspecialchars($a['start_time']); ?></td>
+  <td><?= htmlspecialchars($a['end_time']); ?></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<h4>新增紧急事务</h4>
+<form method="post" class="mt-3">
+  <input type="hidden" name="action" value="add">
+  <div class="mb-3">
+    <label class="form-label">紧急事务描述</label>
+    <textarea name="description" class="form-control" rows="2" required></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">起始时间</label>
+    <input type="datetime-local" name="start_time" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">结束时间</label>
+    <input type="datetime-local" name="end_time" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">提交</button>
+</form>
+<?php endif; ?>
+</body>
+</html>

--- a/tasks.php
+++ b/tasks.php
@@ -35,6 +35,7 @@ if($status){
   <td>
     <a class="btn btn-sm btn-primary" href="task_edit.php?id=<?= $t['id']; ?>">编辑信息</a>
     <a class="btn btn-sm btn-warning" href="task_affairs.php?id=<?= $t['id']; ?>">下辖紧急事务</a>
+    <a class="btn btn-sm btn-info" href="task_member_fill.php?task_id=<?= $t['id']; ?>">Ask for Members to Fill Up</a>
     <a class="btn btn-sm btn-danger" href="task_delete.php?id=<?= $t['id']; ?>" onclick="return doubleConfirm('Delete task?');">删除</a>
   </td>
 </tr>

--- a/workload.php
+++ b/workload.php
@@ -6,32 +6,7 @@ $report = [];
 if($start && $end){
     $members = $pdo->query('SELECT id, campus_id, name FROM members')->fetchAll();
     foreach($members as $m){
-        $total_project = 0;
         $total_task = 0;
-        $project_hours = [];
-        $stmt = $pdo->prepare('SELECT project_id, join_time, exit_time FROM project_member_log WHERE member_id=? AND join_time < ? AND (exit_time IS NULL OR exit_time > ?)');
-        $stmt->execute([$m['id'],$end,$start]);
-        foreach($stmt as $row){
-            $join = max($row['join_time'],$start);
-            $exit = $row['exit_time'] ? min($row['exit_time'],$end) : $end;
-            if(strtotime($exit) > strtotime($join)){
-                $seconds = strtotime($exit) - strtotime($join);
-                $project_hours[$row['project_id']] = ($project_hours[$row['project_id']] ?? 0) + $seconds;
-                $total_project += $seconds;
-            }
-        }
-        $projects = [];
-        if($project_hours){
-            $ids = array_keys($project_hours);
-            $placeholders = implode(',', array_fill(0, count($ids), '?'));
-            $titles_stmt = $pdo->prepare("SELECT id, title FROM projects WHERE id IN ($placeholders)");
-            $titles_stmt->execute($ids);
-            $titles = $titles_stmt->fetchAll(PDO::FETCH_KEY_PAIR);
-            foreach($project_hours as $pid=>$sec){
-                $projects[] = ['title'=>$titles[$pid] ?? ('Project '.$pid),'hours'=>round($sec/3600,2)];
-            }
-        }
-
         $task_hours = [];
         $stmt = $pdo->prepare('SELECT t.title, a.description, a.start_time, a.end_time FROM task_affairs a JOIN task_affair_members am ON a.id=am.affair_id JOIN tasks t ON a.task_id=t.id WHERE am.member_id=? AND a.start_time < ? AND a.end_time > ?');
         $stmt->execute([$m['id'],$end,$start]);
@@ -53,11 +28,9 @@ if($start && $end){
         $report[] = [
             'campus_id'=>$m['campus_id'],
             'name'=>$m['name'],
-            'projects'=>$projects,
             'tasks'=>$tasks,
-            'project_total'=>round($total_project/3600,2),
             'task_total'=>round($total_task/3600,2),
-            'total_hours'=>round(($total_project+$total_task)/3600,2)
+            'total_hours'=>round($total_task/3600,2)
         ];
     }
     usort($report, function($a,$b){ return $b['total_hours'] <=> $a['total_hours']; });
@@ -69,23 +42,17 @@ if($start && $end){
         header('Content-Disposition: attachment; filename="workload.xls"');
         echo "\xEF\xBB\xBF"; // UTF-8 BOM for Excel
         echo "<table border='1'>";
-        echo "<tr><th>排名</th><th>一卡通号</th><th>姓名</th><th>项目</th><th>紧急任务</th><th>项目时长</th><th>紧急任务时长</th></tr>";
+        echo "<tr><th>排名</th><th>一卡通号</th><th>姓名</th><th>紧急任务</th><th>紧急任务时长</th></tr>";
         foreach($report as $r){
             echo "<tr>";
             echo "<td>".htmlspecialchars($r['rank'])."</td>";
             echo "<td>".htmlspecialchars($r['campus_id'])."</td>";
             echo "<td>".htmlspecialchars($r['name'])."</td>";
             echo "<td>";
-            foreach($r['projects'] as $p){
-                echo htmlspecialchars($p['title'])." (".htmlspecialchars($p['hours'])."h)<br>";
-            }
-            echo "</td>";
-            echo "<td>";
             foreach($r['tasks'] as $t){
                 echo htmlspecialchars($t['key'])." (".htmlspecialchars($t['hours'])."h)<br>";
             }
             echo "</td>";
-            echo "<td>".htmlspecialchars($r['project_total'])."</td>";
             echo "<td>".htmlspecialchars($r['task_total'])."</td>";
             echo "</tr>";
         }
@@ -116,23 +83,17 @@ include 'header.php';
 </form>
 <?php if($report): ?>
 <table class="table table-bordered">
-<tr><th>排名</th><th>一卡通号</th><th>姓名</th><th>项目</th><th>紧急任务</th><th>项目时长</th><th>紧急任务时长</th></tr>
+<tr><th>排名</th><th>一卡通号</th><th>姓名</th><th>紧急任务</th><th>紧急任务时长</th></tr>
 <?php foreach($report as $r): ?>
 <tr>
   <td><?= htmlspecialchars($r['rank']); ?></td>
   <td><?= htmlspecialchars($r['campus_id']); ?></td>
   <td><?= htmlspecialchars($r['name']); ?></td>
   <td>
-    <?php foreach($r['projects'] as $p): ?>
-      <?= htmlspecialchars($p['title']); ?> (<?= htmlspecialchars($p['hours']); ?>h)<br>
-    <?php endforeach; ?>
-  </td>
-  <td>
     <?php foreach($r['tasks'] as $t): ?>
       <?= htmlspecialchars($t['key']); ?> (<?= htmlspecialchars($t['hours']); ?>h)<br>
     <?php endforeach; ?>
   </td>
-  <td><?= htmlspecialchars($r['project_total']); ?></td>
   <td><?= htmlspecialchars($r['task_total']); ?></td>
 </tr>
 <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Expand site layout to 80% width for better use of screen real estate
- Rank workload reports solely by urgent affairs and remove project accounting
- Allow managers to send task-specific links for members to report urgent affairs, with identity verification

## Testing
- `php -l header.php`
- `php -l login.php`
- `php -l member_self_update.php`
- `php -l workload.php`
- `php -l tasks.php`
- `php -l task_member_fill.php`


------
https://chatgpt.com/codex/tasks/task_e_689aff2e29e0832aa22ab12d653bd83a