### PR TITLE
Retrieve task title for member submissions

### DIFF
--- a/task_member_fill.php
+++ b/task_member_fill.php
@@ -5,6 +5,11 @@ if(!$task_id){
     echo 'Invalid task id';
     exit();
 }
+
+$taskStmt = $pdo->prepare('SELECT title FROM tasks WHERE id=?');
+$taskStmt->execute([$task_id]);
+$taskTitle = $taskStmt->fetchColumn();
+if (!$taskTitle) { echo 'Task not found'; exit(); }
 if(isset($_SESSION['fill_task_id']) && $_SESSION['fill_task_id'] != $task_id){
     unset($_SESSION['fill_task_id'], $_SESSION['fill_member_id']);
 }
@@ -54,7 +59,7 @@ if($member_id){
 </style>
 </head>
 <body class="container py-5">
-<h2>工作事务申报 - 与绩效挂钩</h2>
+<h2>工作事务申报 - <?= htmlspecialchars($taskTitle); ?></h2>
 
 <?php if(!$member_id): ?>
 <form method="post" class="mt-4">


### PR DESCRIPTION
## Summary
- Query tasks table for task title and validate task ID
- Display task title in task member submission heading

## Testing
- `php -l task_member_fill.php`


------
https://chatgpt.com/codex/tasks/task_e_689b0e121210832ab32e1eed0a2dae08