### PR TITLE
Filter exited members and enforce task duration limits

### DIFF
--- a/directions.php
+++ b/directions.php
@@ -3,7 +3,7 @@
 $stmt = $pdo->query("SELECT d.*, GROUP_CONCAT(CONCAT(m.name, '(', COALESCE(m.degree_pursuing, ''), ',', COALESCE(m.year_of_join, ''), ')') ORDER BY dm.sort_order SEPARATOR ', ') AS member_names
                      FROM research_directions d
                      LEFT JOIN direction_members dm ON d.id = dm.direction_id
-                     LEFT JOIN members m ON dm.member_id = m.id
+                     LEFT JOIN members m ON dm.member_id = m.id AND m.status != 'exited'
                      GROUP BY d.id
                      ORDER BY d.sort_order");
 $directions = $stmt->fetchAll();
@@ -42,7 +42,7 @@ $directions = $stmt->fetchAll();
 <table class="table table-bordered">
   <tr><th>成员</th><th>研究方向</th></tr>
   <?php
-  $memberDirs = $pdo->query('SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(d.title ORDER BY dm.sort_order SEPARATOR ", ") AS dirs FROM members m LEFT JOIN direction_members dm ON m.id=dm.member_id LEFT JOIN research_directions d ON dm.direction_id=d.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
+  $memberDirs = $pdo->query("SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(d.title ORDER BY dm.sort_order SEPARATOR ', ') AS dirs FROM members m LEFT JOIN direction_members dm ON m.id=dm.member_id LEFT JOIN research_directions d ON dm.direction_id=d.id WHERE m.status != 'exited' GROUP BY m.id ORDER BY m.sort_order")->fetchAll();
   foreach($memberDirs as $md): ?>
   <tr>
     <td><?= htmlspecialchars($md["name"]); ?><span style="color:#cccccc;">(<?= htmlspecialchars($md["degree_pursuing"]); ?>,<?= htmlspecialchars($md["year_of_join"]); ?>)</span></td>

--- a/projects.php
+++ b/projects.php
@@ -1,11 +1,11 @@
 <?php include 'header.php';
 $status = $_GET['status'] ?? '';
 if($status){
-    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
+    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id AND m.status != "exited" WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
     $stmt->execute([$status]);
     $projects = $stmt->fetchAll();
 } else {
-    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
+    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id AND m.status != "exited" GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
 }
 ?>
 <div class="d-flex justify-content-between mb-3">
@@ -62,7 +62,7 @@ if($status){
 <table class="table table-bordered">
   <tr><th>成员</th><th>参与项目</th></tr>
   <?php
-  $memberProjects = $pdo->query('SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ", ") AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id GROUP BY m.id ORDER BY m.sort_order')->fetchAll();
+  $memberProjects = $pdo->query("SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ', ') AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id WHERE m.status != 'exited' GROUP BY m.id ORDER BY m.sort_order")->fetchAll();
   foreach($memberProjects as $mp): ?>
   <tr>
     <td><?= htmlspecialchars($mp["name"]); ?><span style="color:#cccccc;">(<?= htmlspecialchars($mp["degree_pursuing"]); ?>,<?= htmlspecialchars($mp["year_of_join"]); ?>)</span></td>

--- a/task_member_fill.php
+++ b/task_member_fill.php
@@ -91,23 +91,52 @@ if($member_id){
 <?php endforeach; ?>
 </table>
 <br>
-<h4>新增工作量</h4>
-<form method="post" class="mt-3">
-  <input type="hidden" name="action" value="add">
-  <div class="mb-3">
-    <label class="form-label">工作事务描述(例如跑腿、开会、出差、临时材料等事务)</label>
-    <textarea name="description" class="form-control" rows="2" required></textarea>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">起始时间（请诚信填写，时长与工资挂钩）</label>
-    <input type="datetime-local" name="start_time" class="form-control" required>
-  </div>
-  <div class="mb-3">
-    <label class="form-label">结束时间（请诚信填写，时长与工资挂钩）</label>
-    <input type="datetime-local" name="end_time" class="form-control" required>
-  </div>
-  <button type="submit" class="btn btn-primary">申报该工作量</button>
-</form>
+ <h4>新增工作量</h4>
+ <form method="post" class="mt-3" id="taskForm">
+   <input type="hidden" name="action" value="add">
+   <div class="mb-3">
+     <label class="form-label">工作事务描述(例如跑腿、开会、出差、临时材料等事务)</label>
+     <textarea name="description" class="form-control" rows="2" required></textarea>
+   </div>
+   <div class="mb-3">
+     <label class="form-label">起始时间（请诚信填写，时长与工资挂钩）</label>
+     <input type="datetime-local" name="start_time" id="startTime" class="form-control" required>
+   </div>
+   <div class="mb-3">
+     <label class="form-label">结束时间（请诚信填写，时长与工资挂钩）</label>
+     <input type="datetime-local" name="end_time" id="endTime" class="form-control" required>
+     <div id="timeWarning" class="text-danger mt-2" style="display:none;">请确认您所选择的任务时长，任务不得超过6天，超过6天的任务请切分填写（注意此处任务需保持较细颗粒度，便于考核）</div>
+   </div>
+   <button type="submit" class="btn btn-primary">申报该工作量</button>
+ </form>
+ <script>
+ const startInput = document.getElementById('startTime');
+ const endInput = document.getElementById('endTime');
+ const warning = document.getElementById('timeWarning');
+ const form = document.getElementById('taskForm');
+ function checkInterval(){
+   const start = new Date(startInput.value);
+   const end = new Date(endInput.value);
+   if(startInput.value && endInput.value){
+     const diff = (end - start) / (1000 * 60 * 60 * 24);
+     if(diff > 6){
+       warning.style.display = 'block';
+       endInput.value = '';
+       return false;
+     } else {
+       warning.style.display = 'none';
+     }
+   }
+   return true;
+ }
+ startInput.addEventListener('change', checkInterval);
+ endInput.addEventListener('change', checkInterval);
+ form.addEventListener('submit', function(e){
+   if(!checkInterval()){
+     e.preventDefault();
+   }
+ });
+ </script>
 <?php endif; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Hide members marked as exited from direction and project pages
- Validate task duration client-side and warn when exceeding six days

## Testing
- `php -l directions.php`
- `php -l projects.php`
- `php -l task_member_fill.php`


------
https://chatgpt.com/codex/tasks/task_e_689b328a0e94832a9d3113717cc6e881