### PR TITLE
Hide exited members from workload and selection pages

### DIFF
--- a/direction_members.php
+++ b/direction_members.php
@@ -11,7 +11,7 @@ $direction = $direction_stmt->fetch();
 $current_stmt = $pdo->prepare('SELECT m.id, m.campus_id, m.name FROM direction_members dm JOIN members m ON dm.member_id=m.id WHERE dm.direction_id=? ORDER BY dm.sort_order');
 $current_stmt->execute([$direction_id]);
 $current_members = $current_stmt->fetchAll();
-$members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')->fetchAll();
+$members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited' ORDER BY name")->fetchAll();
 ?>
 <h2>研究方向成员 - <?= htmlspecialchars($direction['title']); ?></h2>
 <table class="table table-bordered">

--- a/project_members.php
+++ b/project_members.php
@@ -14,7 +14,7 @@ $active_members = $active->fetchAll();
 $logs = $pdo->prepare('SELECT l.*, m.name, m.campus_id FROM project_member_log l JOIN members m ON l.member_id=m.id WHERE l.project_id=? ORDER BY l.join_time');
 $logs->execute([$project_id]);
 $logs = $logs->fetchAll();
-$members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')->fetchAll();
+$members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited' ORDER BY name")->fetchAll();
 ?>
 <h2>项目成员 - <?php echo htmlspecialchars($project['title']); ?></h2>
 <h4>当前成员</h4>

--- a/task_affairs.php
+++ b/task_affairs.php
@@ -11,7 +11,7 @@ $task = $task->fetch();
 $affairs_stmt = $pdo->prepare('SELECT a.*, GROUP_CONCAT(CONCAT(m.name, " (", m.campus_id, ")") SEPARATOR ", ") AS members FROM task_affairs a LEFT JOIN task_affair_members am ON a.id=am.affair_id LEFT JOIN members m ON am.member_id=m.id WHERE a.task_id=? GROUP BY a.id ORDER BY a.start_time DESC');
 $affairs_stmt->execute([$task_id]);
 $affairs = $affairs_stmt->fetchAll();
-$members = $pdo->query('SELECT id, campus_id, name FROM members ORDER BY name')->fetchAll();
+$members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited' ORDER BY name")->fetchAll();
 ?>
 <h2>下辖具体事务 - <?php echo htmlspecialchars($task['title']); ?></h2>
 <table class="table table-bordered">

--- a/workload.php
+++ b/workload.php
@@ -4,7 +4,7 @@ $start = $_GET['start'] ?? '';
 $end = $_GET['end'] ?? '';
 $report = [];
 if($start && $end){
-    $members = $pdo->query('SELECT id, campus_id, name FROM members')->fetchAll();
+    $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited'")->fetchAll();
     foreach($members as $m){
         $total_task = 0;
         $task_hours = [];


### PR DESCRIPTION
## Summary
- Exclude exited members from workload reports
- Filter member selection lists to show only active members

## Testing
- `php -l direction_members.php project_members.php task_affairs.php workload.php`


------
https://chatgpt.com/codex/tasks/task_e_689b3cb0567c832ab3e46f69556192ac