### PR TITLE
Ensure end dates come after start dates

### DIFF
--- a/affair_add.php
+++ b/affair_add.php
@@ -6,6 +6,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     $member_ids = $_POST['member_ids'] ?? [];
     $start_time = $_POST['start_time'];
     $end_time = $_POST['end_time'];
+    if(strtotime($end_time) <= strtotime($start_time)){
+        echo '结束时间必须晚于起始时间';
+        exit();
+    }
     $stmt = $pdo->prepare('INSERT INTO task_affairs(task_id,description,start_time,end_time) VALUES (?,?,?,?)');
     $stmt->execute([$task_id,$description,$start_time,$end_time]);
     $affair_id = $pdo->lastInsertId();

--- a/task_affairs.php
+++ b/task_affairs.php
@@ -53,4 +53,15 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
   <button type="submit" class="btn btn-primary">新增事务</button>
   <a href="tasks.php" class="btn btn-secondary">返回</a>
 </form>
+<script>
+const affairForm = document.querySelector('form[action="affair_add.php"]');
+affairForm.addEventListener('submit', function(e){
+  const start = affairForm.querySelector('input[name="start_time"]').value;
+  const end = affairForm.querySelector('input[name="end_time"]').value;
+  if(start && end && new Date(end) <= new Date(start)){
+    alert('结束时间必须晚于起始时间');
+    e.preventDefault();
+  }
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/workload.php
+++ b/workload.php
@@ -3,8 +3,12 @@ include 'auth.php';
 $start = $_GET['start'] ?? '';
 $end = $_GET['end'] ?? '';
 $report = [];
+$error = '';
 if($start && $end){
-    $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited'")->fetchAll();
+    if(strtotime($end) <= strtotime($start)){
+        $error = '报表截止时间必须晚于起始时间';
+    } else {
+        $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited'")->fetchAll();
     foreach($members as $m){
         $total_task = 0;
         $task_hours = [];
@@ -59,10 +63,12 @@ if($start && $end){
         echo "</table>";
         exit();
     }
+    }
 }
 include 'header.php';
 ?>
 <h2>工作量统计报表</h2>
+<?php if($error): ?><div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div><?php endif; ?>
 <form method="get" class="row g-3 mb-3">
   <div class="col-auto">
     <label class="form-label">报表起始时间</label>
@@ -81,6 +87,17 @@ include 'header.php';
   </div>
   <?php endif; ?>
 </form>
+<script>
+const rangeForm = document.querySelector('form');
+rangeForm.addEventListener('submit', function(e){
+  const startField = rangeForm.querySelector('input[name="start"]').value;
+  const endField = rangeForm.querySelector('input[name="end"]').value;
+  if(startField && endField && new Date(endField) <= new Date(startField)){
+    alert('报表截止时间必须晚于起始时间');
+    e.preventDefault();
+  }
+});
+</script>
 <?php if($report): ?>
 <table class="table table-bordered">
 <tr><th>排名</th><th>一卡通号</th><th>姓名</th><th>紧急任务</th><th>紧急任务时长</th></tr>


### PR DESCRIPTION
## Summary
- validate project begin and end dates on the server and client
- guard task affair creation with start/end time checks
- enforce proper time ranges on member submissions and workload reports

## Testing
- `php -l project_edit.php`
- `php -l task_affairs.php`
- `php -l task_member_fill.php`
- `php -l affair_add.php`
- `php -l workload.php`


------
https://chatgpt.com/codex/tasks/task_e_689b4088b194832a8edb1007a698d771