### PR TITLE
Simplify urgent affair scheduling to day granularity

### DIFF
--- a/affair_add.php
+++ b/affair_add.php
@@ -4,12 +4,14 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
     $task_id = $_POST['task_id'];
     $description = $_POST['description'];
     $member_ids = $_POST['member_ids'] ?? [];
-    $start_time = $_POST['start_time'];
-    $end_time = $_POST['end_time'];
-    if(strtotime($end_time) <= strtotime($start_time)){
-        echo '结束时间必须晚于起始时间';
+    $start_date = $_POST['start_time'];
+    $end_date = $_POST['end_time'];
+    if(strtotime($end_date) < strtotime($start_date)){
+        echo '结束日期必须不早于起始日期';
         exit();
     }
+    $start_time = $start_date . ' 00:00:00';
+    $end_time = date('Y-m-d 00:00:00', strtotime($end_date . ' +1 day'));
     $stmt = $pdo->prepare('INSERT INTO task_affairs(task_id,description,start_time,end_time) VALUES (?,?,?,?)');
     $stmt->execute([$task_id,$description,$start_time,$end_time]);
     $affair_id = $pdo->lastInsertId();

--- a/workload_adjustment.sql
+++ b/workload_adjustment.sql
@@ -1,0 +1,6 @@
+-- Adjust existing task affair times to align with day-based workload
+-- Sets start_time to midnight of its date and end_time to midnight of the next day
+UPDATE task_affairs
+SET start_time = DATE_FORMAT(start_time, '%Y-%m-%d 00:00:00'),
+    end_time   = DATE_FORMAT(DATE_ADD(DATE(end_time), INTERVAL 1 DAY), '%Y-%m-%d 00:00:00')
+WHERE 1;


### PR DESCRIPTION
## Summary
- Allow members and managers to schedule urgent affairs using dates only and display calculated day counts.
- Beautify member workload submission warnings for clearer guidance.
- Add SQL script to normalize existing minute-level workload entries to day-level.

## Testing
- `php -l task_member_fill.php`
- `php -l affair_add.php`
- `php -l task_affairs.php`


------
https://chatgpt.com/codex/tasks/task_e_689bf974627c832aba9171e8a4442bbe