### PR TITLE
Enhance project and direction management

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -34,6 +34,7 @@ CREATE TABLE projects (
   sort_order INT DEFAULT 0,
   title VARCHAR(100) NOT NULL,
   description TEXT,
+  bg_color VARCHAR(20),
   begin_date DATE,
   end_date DATE,
   status ENUM('todo','ongoing','paused','finished') DEFAULT 'todo'
@@ -44,8 +45,8 @@ CREATE TABLE project_member_log (
   project_id INT NOT NULL,
   member_id INT NOT NULL,
   sort_order INT DEFAULT 0,
-  join_time DATETIME NOT NULL,
-  exit_time DATETIME DEFAULT NULL,
+  join_time DATE NOT NULL,
+  exit_time DATE DEFAULT NULL,
   FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE,
   FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
 );
@@ -79,7 +80,8 @@ CREATE TABLE research_directions (
   id INT AUTO_INCREMENT PRIMARY KEY,
   sort_order INT DEFAULT 0,
   title VARCHAR(100) NOT NULL,
-  description TEXT
+  description TEXT,
+  bg_color VARCHAR(20)
 );
 
 CREATE TABLE direction_members (

--- a/direction_edit.php
+++ b/direction_edit.php
@@ -1,7 +1,7 @@
 <?php
 include 'header.php';
 $id = $_GET['id'] ?? null;
-$direction = ['title'=>'','description'=>''];
+$direction = ['title'=>'','description'=>'','bg_color'=>'#ffffff'];
 if($id){
     $stmt = $pdo->prepare('SELECT * FROM research_directions WHERE id=?');
     $stmt->execute([$id]);
@@ -10,14 +10,15 @@ if($id){
 if($_SERVER['REQUEST_METHOD']==='POST'){
     $title = $_POST['title'];
     $description = $_POST['description'];
+    $bg_color = $_POST['bg_color'];
     if($id){
-        $stmt = $pdo->prepare('UPDATE research_directions SET title=?, description=? WHERE id=?');
-        $stmt->execute([$title,$description,$id]);
+        $stmt = $pdo->prepare('UPDATE research_directions SET title=?, description=?, bg_color=? WHERE id=?');
+        $stmt->execute([$title,$description,$bg_color,$id]);
     } else {
         $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM research_directions');
         $nextOrder = $orderStmt->fetchColumn();
-        $stmt = $pdo->prepare('INSERT INTO research_directions(title,description,sort_order) VALUES (?,?,?)');
-        $stmt->execute([$title,$description,$nextOrder]);
+        $stmt = $pdo->prepare('INSERT INTO research_directions(title,description,bg_color,sort_order) VALUES (?,?,?,?)');
+        $stmt->execute([$title,$description,$bg_color,$nextOrder]);
     }
     header('Location: directions.php');
     exit();
@@ -32,6 +33,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
   <div class="mb-3">
     <label class="form-label">方向具体描述</label>
     <textarea name="description" class="form-control" rows="3"><?= htmlspecialchars($direction['description']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">背景颜色</label>
+    <input type="color" name="bg_color" class="form-control form-control-color" value="<?= htmlspecialchars($direction['bg_color'] ?? '#ffffff'); ?>">
   </div>
   <button type="submit" class="btn btn-primary">保存</button>
   <a href="directions.php" class="btn btn-secondary">取消</a>

--- a/directions.php
+++ b/directions.php
@@ -14,6 +14,10 @@ $directions = $stmt->fetchAll();
     <a class="btn btn-success" href="direction_edit.php" data-i18n="directions.add">Add Direction</a>
   </div>
 </div>
+<div class="form-check form-switch mb-3">
+  <input class="form-check-input" type="checkbox" id="detailToggle" checked>
+  <label class="form-check-label" for="detailToggle">显示成员详情</label>
+</div>
 <table class="table table-bordered">
   <thead>
   <tr>
@@ -25,10 +29,19 @@ $directions = $stmt->fetchAll();
   </thead>
   <tbody id="directionList">
   <?php foreach($directions as $d): ?>
-  <tr data-id="<?= $d['id']; ?>">
+  <tr data-id="<?= $d['id']; ?>"<?= $d['bg_color'] ? ' style="background-color:'.htmlspecialchars($d['bg_color']).';"' : ''; ?>>
     <td class="drag-handle">&#9776;</td>
     <td><?= htmlspecialchars($d['title']); ?></td>
-    <td><?= $d['member_names'] ? preg_replace('/\([^()]*\)/', '<span style="color:#cccccc;">$0</span>', htmlspecialchars($d['member_names'])) : '<em data-i18n="directions.none">None</em>'; ?></td>
+    <td>
+      <?php
+      if ($d['member_names']) {
+          $escaped = htmlspecialchars($d['member_names']);
+          echo preg_replace('/\(([^()]*)\)/', '<span class="member-detail text-muted">($1)</span>', $escaped);
+      } else {
+          echo '<em data-i18n="directions.none">None</em>';
+      }
+      ?>
+    </td>
     <td>
       <a class="btn btn-sm btn-primary" href="direction_edit.php?id=<?= $d['id']; ?>" data-i18n="directions.action_edit">Edit</a>
       <a class="btn btn-sm btn-warning" href="direction_members.php?id=<?= $d['id']; ?>" data-i18n="directions.action_members">Members</a>
@@ -45,7 +58,7 @@ $directions = $stmt->fetchAll();
   $memberDirs = $pdo->query("SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(d.title ORDER BY dm.sort_order SEPARATOR ', ') AS dirs FROM members m LEFT JOIN direction_members dm ON m.id=dm.member_id LEFT JOIN research_directions d ON dm.direction_id=d.id WHERE m.status != 'exited' GROUP BY m.id ORDER BY m.sort_order")->fetchAll();
   foreach($memberDirs as $md): ?>
   <tr>
-    <td><?= htmlspecialchars($md["name"]); ?><span style="color:#cccccc;">(<?= htmlspecialchars($md["degree_pursuing"]); ?>,<?= htmlspecialchars($md["year_of_join"]); ?>)</span></td>
+    <td><?= htmlspecialchars($md["name"]); ?><span class="member-detail text-muted">(<?= htmlspecialchars($md["degree_pursuing"]); ?>,<?= htmlspecialchars($md["year_of_join"]); ?>)</span></td>
     <td><?= $md['dirs'] ? htmlspecialchars($md['dirs']) : '<span style="color:red"><em>暂无</em></span>'; ?></td>
   </tr>
   <?php endforeach; ?>
@@ -64,6 +77,12 @@ document.addEventListener('DOMContentLoaded', function(){
         body: JSON.stringify({order: order})
       });
     }
+  });
+
+  document.getElementById('detailToggle').addEventListener('change', function(){
+    document.querySelectorAll('.member-detail').forEach(span => {
+      span.style.display = this.checked ? 'inline' : 'none';
+    });
   });
 });
 </script>

--- a/project_edit.php
+++ b/project_edit.php
@@ -1,7 +1,7 @@
 <?php
 include 'header.php';
 $id = $_GET['id'] ?? null;
-$project = ['title'=>'','description'=>'','begin_date'=>'','end_date'=>'','status'=>'todo'];
+$project = ['title'=>'','description'=>'','bg_color'=>'#ffffff','begin_date'=>'','end_date'=>'','status'=>'todo'];
 $error = '';
 if($id){
     $stmt = $pdo->prepare('SELECT * FROM projects WHERE id=?');
@@ -11,6 +11,7 @@ if($id){
 if($_SERVER['REQUEST_METHOD']==='POST'){
     $title = $_POST['title'];
     $description = $_POST['description'];
+    $bg_color = $_POST['bg_color'];
     $begin_date = $_POST['begin_date'];
     $end_date = $_POST['end_date'];
     $status = $_POST['status'];
@@ -18,13 +19,13 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
         $error = '结项时间必须晚于立项时间';
     } else {
         if($id){
-            $stmt = $pdo->prepare('UPDATE projects SET title=?, description=?, begin_date=?, end_date=?, status=? WHERE id=?');
-            $stmt->execute([$title,$description,$begin_date,$end_date,$status,$id]);
+            $stmt = $pdo->prepare('UPDATE projects SET title=?, description=?, bg_color=?, begin_date=?, end_date=?, status=? WHERE id=?');
+            $stmt->execute([$title,$description,$bg_color,$begin_date,$end_date,$status,$id]);
         } else {
             $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM projects');
             $nextOrder = $orderStmt->fetchColumn();
-            $stmt = $pdo->prepare('INSERT INTO projects(title,description,begin_date,end_date,status,sort_order) VALUES (?,?,?,?,?,?)');
-            $stmt->execute([$title,$description,$begin_date,$end_date,$status,$nextOrder]);
+            $stmt = $pdo->prepare('INSERT INTO projects(title,description,bg_color,begin_date,end_date,status,sort_order) VALUES (?,?,?,?,?,?,?)');
+            $stmt->execute([$title,$description,$bg_color,$begin_date,$end_date,$status,$nextOrder]);
         }
         header('Location: projects.php');
         exit();
@@ -41,6 +42,10 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
   <div class="mb-3">
     <label class="form-label">项目描述</label>
     <textarea name="description" class="form-control" rows="3"><?php echo htmlspecialchars($project['description']); ?></textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">背景颜色</label>
+    <input type="color" name="bg_color" class="form-control form-control-color" value="<?php echo htmlspecialchars($project['bg_color'] ?? '#ffffff'); ?>">
   </div>
   <div class="mb-3">
     <label class="form-label">立项时间</label>

--- a/project_member_remove.php
+++ b/project_member_remove.php
@@ -17,8 +17,8 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
 <h2>Remove Member</h2>
 <form method="post">
   <div class="mb-3">
-    <label class="form-label">Exit Time</label>
-    <input type="datetime-local" name="exit_time" class="form-control" required>
+    <label class="form-label">Exit Date</label>
+    <input type="date" name="exit_time" class="form-control" required>
   </div>
   <button type="submit" class="btn btn-danger">Remove</button>
   <a href="project_members.php?id=<?= $project_id; ?>" class="btn btn-secondary">Cancel</a>

--- a/project_members.php
+++ b/project_members.php
@@ -19,7 +19,7 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
 <h2>项目成员 - <?php echo htmlspecialchars($project['title']); ?></h2>
 <h4>当前成员</h4>
 <table class="table table-bordered">
-<tr><th></th><th>一卡通号</th><th>姓名</th><th>入项时间</th><th>操作</th></tr>
+<tr><th></th><th>一卡通号</th><th>姓名</th><th>入项日期</th><th>操作</th></tr>
 <tbody id="memberList">
 <?php foreach($active_members as $a): ?>
 <tr data-id="<?= $a['id']; ?>">
@@ -46,8 +46,8 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
     </select>
   </div>
   <div class="mb-3">
-    <label class="form-label">入项时间</label>
-    <input type="datetime-local" name="join_time" class="form-control" required>
+    <label class="form-label">入项日期</label>
+    <input type="date" name="join_time" class="form-control" required>
   </div>
   <button type="submit" class="btn btn-primary">新增</button>
   <a href="projects.php" class="btn btn-secondary">返回</a>
@@ -55,7 +55,7 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
 <br>
 <h4 class="mt-5">成员变动历史</h4>
 <table class="table table-bordered">
-<tr><th>成员</th><th>入项时间</th><th>退出时间</th></tr>
+<tr><th>成员</th><th>入项日期</th><th>退出日期</th></tr>
 <?php foreach($logs as $l): ?>
 <tr>
   <td><?= htmlspecialchars($l['name']); ?> (<?= htmlspecialchars($l['campus_id']); ?>)</td>

--- a/projects.php
+++ b/projects.php
@@ -1,11 +1,16 @@
 <?php include 'header.php';
 $status = $_GET['status'] ?? '';
+$dirMapStmt = $pdo->query("SELECT dm.member_id, GROUP_CONCAT(rd.title SEPARATOR ', ') AS dirs FROM direction_members dm JOIN research_directions rd ON dm.direction_id=rd.id GROUP BY dm.member_id");
+$memberDirections = [];
+foreach($dirMapStmt as $row){
+    $memberDirections[$row['member_id']] = $row['dirs'];
+}
 if($status){
-    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id AND m.status != "exited" WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
+    $stmt = $pdo->prepare('SELECT p.*, GROUP_CONCAT(CONCAT(m.id, "|", m.name, "|", COALESCE(m.degree_pursuing, ""), "|", COALESCE(m.year_of_join, "")) ORDER BY l.sort_order SEPARATOR ";") AS member_data FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id AND m.status != "exited" WHERE p.status=? GROUP BY p.id ORDER BY p.sort_order');
     $stmt->execute([$status]);
     $projects = $stmt->fetchAll();
 } else {
-    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(CONCAT(m.name, "(", COALESCE(m.degree_pursuing, ""), ",", COALESCE(m.year_of_join, ""), ")") ORDER BY l.sort_order SEPARATOR ", ") AS members FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id AND m.status != "exited" GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
+    $projects = $pdo->query('SELECT p.*, GROUP_CONCAT(CONCAT(m.id, "|", m.name, "|", COALESCE(m.degree_pursuing, ""), "|", COALESCE(m.year_of_join, "")) ORDER BY l.sort_order SEPARATOR ";") AS member_data FROM projects p LEFT JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL LEFT JOIN members m ON l.member_id=m.id AND m.status != "exited" GROUP BY p.id ORDER BY p.sort_order')->fetchAll();
 }
 ?>
 <div class="d-flex justify-content-between mb-3">
@@ -28,6 +33,10 @@ if($status){
     <button type="submit" class="btn btn-primary" data-i18n="projects.filter.button">Filter</button>
   </div>
 </form>
+<div class="form-check form-switch mb-3">
+  <input class="form-check-input" type="checkbox" id="detailToggle" checked>
+  <label class="form-check-label" for="detailToggle">显示成员详情</label>
+</div>
 <table class="table table-bordered">
   <thead>
   <tr>
@@ -42,10 +51,31 @@ if($status){
   </thead>
   <tbody id="projectList">
   <?php foreach($projects as $p): ?>
-  <tr data-id="<?= $p['id']; ?>">
+  <?php
+    $memberList = [];
+    if ($p['member_data']) {
+        foreach(explode(';', $p['member_data']) as $md){
+            if(!$md) continue;
+            list($mid,$mname,$mdegree,$myear) = explode('|',$md);
+            $memberList[] = ['id'=>$mid,'name'=>$mname,'degree'=>$mdegree,'year'=>$myear];
+        }
+    }
+  ?>
+  <tr data-id="<?= $p['id']; ?>"<?= $p['bg_color'] ? ' style="background-color:'.htmlspecialchars($p['bg_color']).';"' : ''; ?>>
     <td class="drag-handle">&#9776;</td>
     <td><?= htmlspecialchars($p['title']); ?></td>
-    <td><?= preg_replace('/\([^()]*\)/', '<span style="color:#cccccc;">$0</span>', htmlspecialchars($p['members'])); ?></td>
+    <td>
+      <?php if($memberList): ?>
+        <?php foreach($memberList as $idx=>$m): ?>
+          <span class="member-name" data-bs-toggle="tooltip" title="<?= htmlspecialchars($memberDirections[$m['id']] ?? '无研究方向'); ?>">
+            <?= htmlspecialchars($m['name']); ?>
+            <span class="member-detail text-muted">(<?= htmlspecialchars($m['degree']); ?>,<?= htmlspecialchars($m['year']); ?>)</span>
+          </span><?= $idx < count($memberList)-1 ? ', ' : ''; ?>
+        <?php endforeach; ?>
+      <?php else: ?>
+        <em data-i18n="directions.none">None</em>
+      <?php endif; ?>
+    </td>
     <td><?= htmlspecialchars($p['begin_date']); ?></td>
     <td><?= htmlspecialchars($p['end_date']); ?></td>
     <td><?= htmlspecialchars($p['status']); ?></td>
@@ -65,7 +95,7 @@ if($status){
   $memberProjects = $pdo->query("SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ', ') AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id WHERE m.status != 'exited' GROUP BY m.id ORDER BY m.sort_order")->fetchAll();
   foreach($memberProjects as $mp): ?>
   <tr>
-    <td><?= htmlspecialchars($mp["name"]); ?><span style="color:#cccccc;">(<?= htmlspecialchars($mp["degree_pursuing"]); ?>,<?= htmlspecialchars($mp["year_of_join"]); ?>)</span></td>
+    <td><?= htmlspecialchars($mp["name"]); ?><span class="member-detail text-muted">(<?= htmlspecialchars($mp["degree_pursuing"]); ?>,<?= htmlspecialchars($mp["year_of_join"]); ?>)</span></td>
     <td><?= $mp['proj'] ? htmlspecialchars($mp['proj']) : '<span style="color:red"><em>暂无</em></span>'; ?></td>
   </tr>
   <?php endforeach; ?>
@@ -85,6 +115,15 @@ document.addEventListener('DOMContentLoaded', function(){
       });
     }
   });
+
+  document.getElementById('detailToggle').addEventListener('change', function(){
+    document.querySelectorAll('.member-detail').forEach(span => {
+      span.style.display = this.checked ? 'inline' : 'none';
+    });
+  });
+
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.map(function (tooltipTriggerEl) { return new bootstrap.Tooltip(tooltipTriggerEl); });
 });
 </script>
 <?php include 'footer.php'; ?>

--- a/task_affairs.php
+++ b/task_affairs.php
@@ -38,7 +38,7 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
   </div>
   <div class="mb-3">
     <label class="form-label">负责成员 (按住Ctrl键点选多个人)</label>
-    <select name="member_ids[]" class="form-select" multiple required>
+    <select name="member_ids[]" class="form-select" multiple required size="10">
       <?php foreach($members as $m): ?>
       <option value="<?= $m['id']; ?>"><?= htmlspecialchars($m['name']); ?> (<?= $m['campus_id']; ?>)</option>
       <?php endforeach; ?>

--- a/update_db.sql
+++ b/update_db.sql
@@ -1,0 +1,4 @@
+ALTER TABLE project_member_log MODIFY join_time DATE NOT NULL;
+ALTER TABLE project_member_log MODIFY exit_time DATE DEFAULT NULL;
+ALTER TABLE projects ADD COLUMN bg_color VARCHAR(20) DEFAULT NULL;
+ALTER TABLE research_directions ADD COLUMN bg_color VARCHAR(20) DEFAULT NULL;


### PR DESCRIPTION
## Summary
- Increase member selector height in task affairs
- Use date-only member join/exit and allow toggling of member details
- Add background colors and tooltips for projects and directions

## Testing
- `php -l task_affairs.php project_members.php project_member_remove.php project_edit.php direction_edit.php projects.php directions.php`


------
https://chatgpt.com/codex/tasks/task_e_689c01dbd29c832a95139caa0ba47d68