### PR TITLE
Ensure member details greyed and row backgrounds applied

### DIFF
--- a/header.php
+++ b/header.php
@@ -8,6 +8,8 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
   .container { max-width: 80%; }
+  .member-detail { color: #CCCCCC !important; }
+  tr[style*="background-color"] > * { background-color: inherit !important; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Gray out member detail text such as degrees and join years using #CCCCCC.
- Make table rows respect stored background colors by inheriting them into cells.

## Testing
- `php -l header.php`
- `php -l directions.php`
- `php -l projects.php`


------
https://chatgpt.com/codex/tasks/task_e_689c0878130c832a9000fd8828732568