### PR TITLE
Display QR code popups for member actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -159,4 +159,16 @@ document.addEventListener('DOMContentLoaded', () => {
     applyTheme();
     applyTranslations();
   });
+
+  document.querySelectorAll('.qr-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const url = btn.dataset.url;
+      const img = document.getElementById('qrImage');
+      if (url && img) {
+        img.src = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' + encodeURIComponent(url);
+        const modal = new bootstrap.Modal(document.getElementById('qrModal'));
+        modal.show();
+      }
+    });
+  });
 });

--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,17 @@
 </div>
+<div class="modal fade" id="qrModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">扫码进入</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <img id="qrImage" src="" alt="QR Code">
+      </div>
+    </div>
+  </div>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script src="app.js"></script>
 </body>

--- a/members.php
+++ b/members.php
@@ -42,7 +42,7 @@ $members = $stmt->fetchAll();
     <a class="btn btn-success" href="member_edit.php">新增成员</a>
     <a class="btn btn-secondary" href="members_import.php">从表格导入</a>
     <a class="btn btn-secondary" href="members_export.php">导出至表格</a>
-    <a class="btn btn-warning" href="member_self_update.php">请求信息更新</a>
+    <button type="button" class="btn btn-warning qr-btn" data-url="member_self_update.php">请求信息更新</button>
   </div>
 </div>
 <div class="mb-3">

--- a/tasks.php
+++ b/tasks.php
@@ -35,7 +35,7 @@ if($status){
   <td>
     <a class="btn btn-sm btn-primary" href="task_edit.php?id=<?= $t['id']; ?>">编辑信息</a>
     <a class="btn btn-sm btn-warning" href="task_affairs.php?id=<?= $t['id']; ?>">下辖具体事务</a>
-    <a class="btn btn-sm btn-info" href="task_member_fill.php?task_id=<?= $t['id']; ?>">请成员自己填</a>
+    <button type="button" class="btn btn-sm btn-info qr-btn" data-url="task_member_fill.php?task_id=<?= $t['id']; ?>">请成员自己填</button>
     <a class="btn btn-sm btn-danger" href="task_delete.php?id=<?= $t['id']; ?>" onclick="return doubleConfirm('Delete task?');">删除</a>
   </td>
 </tr>


### PR DESCRIPTION
## Summary
- Show QR code modal instead of navigating directly for task member self-fill links
- Display QR code for requesting member information updates
- Add reusable QR code modal and JavaScript handler

## Testing
- `php -l tasks.php members.php footer.php`
- `node --check app.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_689c1235a7c4832ab7eac1fc01b71a40