### PR TITLE
feat: add member login and weekly todolist

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'auth.php';
+require_once 'auth_manager.php';
 
 $password_msg = '';
 $add_msg = '';

--- a/affair_add.php
+++ b/affair_add.php
@@ -1,5 +1,5 @@
 <?php
-include 'auth.php';
+include 'auth_manager.php';
 if($_SERVER['REQUEST_METHOD']==='POST'){
     $task_id = $_POST['task_id'];
     $description = $_POST['description'];

--- a/affair_delete.php
+++ b/affair_delete.php
@@ -1,5 +1,5 @@
 <?php
-include 'auth.php';
+include 'auth_manager.php';
 $id = $_GET['id'] ?? null;
 $task_id = $_GET['task_id'] ?? null;
 if($id){

--- a/affair_edit.php
+++ b/affair_edit.php
@@ -1,5 +1,5 @@
 <?php
-include 'auth.php';
+include 'auth_manager.php';
 if($_SERVER['REQUEST_METHOD'] === 'POST'){
     $id = $_POST['id'];
     $task_id = $_POST['task_id'];

--- a/auth.php
+++ b/auth.php
@@ -1,6 +1,6 @@
 <?php
 require_once 'config.php';
-if(!isset($_SESSION['manager_id'])){
+if(!isset($_SESSION['role'])){
     header('Location: login.php');
     exit();
 }

--- a/auth_manager.php
+++ b/auth_manager.php
@@ -1,0 +1,7 @@
+<?php
+require_once 'auth.php';
+if($_SESSION['role'] !== 'manager'){
+    header('Location: index.php');
+    exit();
+}
+?>

--- a/database.sql
+++ b/database.sql
@@ -92,3 +92,15 @@ CREATE TABLE direction_members (
   FOREIGN KEY (direction_id) REFERENCES research_directions(id) ON DELETE CASCADE,
   FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
 );
+
+CREATE TABLE todolist_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  user_role ENUM('manager','member') NOT NULL,
+  week_start DATE NOT NULL,
+  category ENUM('work','personal','longterm') NOT NULL,
+  day ENUM('mon','tue','wed','thu','fri','sat','sun') NULL,
+  content VARCHAR(255) NOT NULL,
+  is_done TINYINT(1) DEFAULT 0,
+  sort_order INT DEFAULT 0
+);

--- a/directions.php
+++ b/directions.php
@@ -1,4 +1,16 @@
 <?php include 'header.php';
+if($_SESSION['role']==='member'){
+    $stmt = $pdo->prepare('SELECT d.* FROM research_directions d JOIN direction_members dm ON d.id=dm.direction_id WHERE dm.member_id=? ORDER BY dm.sort_order');
+    $stmt->execute([$_SESSION['member_id']]);
+    $directions = $stmt->fetchAll();
+?>
+<h2 data-i18n="directions.title">Research Directions</h2>
+<ul>
+<?php foreach($directions as $d): ?>
+  <li><?= htmlspecialchars($d['title']); ?></li>
+<?php endforeach; ?>
+</ul>
+<?php include 'footer.php'; exit; }
 // Fetch research directions along with their members' details
 $stmt = $pdo->query("SELECT d.*, GROUP_CONCAT(CONCAT(m.name, '(', COALESCE(m.degree_pursuing, ''), ',', COALESCE(m.year_of_join, ''), ')') ORDER BY dm.sort_order SEPARATOR ', ') AS member_names
                      FROM research_directions d

--- a/header.php
+++ b/header.php
@@ -20,14 +20,17 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item"><a class="nav-link" href="members.php" data-i18n="nav.members">Members</a></li>
-        <li class="nav-item"><a class="nav-link" href="projects.php" data-i18n="nav.projects">Projects</a></li>
-        <li class="nav-item"><a class="nav-link" href="directions.php" data-i18n="nav.directions">Research</a></li>
-        <li class="nav-item"><a class="nav-link" href="tasks.php" data-i18n="nav.tasks">Tasks</a></li>
-        <li class="nav-item"><a class="nav-link" href="workload.php" data-i18n="nav.workload">Workload</a></li>
-        <li class="nav-item"><a class="nav-link" href="account.php" data-i18n="nav.account">Account</a></li>
-      </ul>
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="members.php" data-i18n="nav.members">Members</a></li>
+          <li class="nav-item"><a class="nav-link" href="todolist.php">Todolist</a></li>
+          <li class="nav-item"><a class="nav-link" href="projects.php" data-i18n="nav.projects">Projects</a></li>
+          <li class="nav-item"><a class="nav-link" href="directions.php" data-i18n="nav.directions">Research</a></li>
+          <?php if($_SESSION['role']==='manager'): ?>
+          <li class="nav-item"><a class="nav-link" href="tasks.php" data-i18n="nav.tasks">Tasks</a></li>
+          <li class="nav-item"><a class="nav-link" href="workload.php" data-i18n="nav.workload">Workload</a></li>
+          <li class="nav-item"><a class="nav-link" href="account.php" data-i18n="nav.account">Account</a></li>
+          <?php endif; ?>
+        </ul>
       <span class="navbar-text me-3"><span data-i18n="welcome">Welcome</span>, <?php echo htmlspecialchars($_SESSION['username']); ?></span>
       <button id="langToggle" class="btn btn-outline-light me-2">中文</button>
       <button id="themeToggle" class="btn btn-outline-light me-2" data-i18n="theme.dark">Dark</button>

--- a/members.php
+++ b/members.php
@@ -1,6 +1,11 @@
 <?php
 include 'header.php';
 
+if($_SESSION['role']==='member'){
+    header('Location: member_self_update.php');
+    exit();
+}
+
 // Determine sorting column and direction from query parameters
 $columns = [
     'campus_id' => '一卡通号',

--- a/projects.php
+++ b/projects.php
@@ -1,4 +1,22 @@
 <?php include 'header.php';
+if($_SESSION['role']==='member'){
+    $stmt = $pdo->prepare('SELECT p.* FROM projects p JOIN project_member_log l ON p.id=l.project_id AND l.exit_time IS NULL WHERE l.member_id=? ORDER BY p.sort_order');
+    $stmt->execute([$_SESSION['member_id']]);
+    $projects = $stmt->fetchAll();
+?>
+<h2 data-i18n="projects.title">Projects</h2>
+<table class="table table-bordered">
+  <tr><th data-i18n="projects.table_title">Title</th><th data-i18n="projects.table_begin">Begin</th><th data-i18n="projects.table_end">End</th><th data-i18n="projects.table_status">Status</th></tr>
+  <?php foreach($projects as $p): ?>
+  <tr>
+    <td><?= htmlspecialchars($p['title']); ?></td>
+    <td><?= htmlspecialchars($p['begin_date']); ?></td>
+    <td><?= htmlspecialchars($p['end_date']); ?></td>
+    <td><?= htmlspecialchars($p['status']); ?></td>
+  </tr>
+  <?php endforeach; ?>
+</table>
+<?php include 'footer.php'; exit; }
 $status = $_GET['status'] ?? '';
 $dirMapStmt = $pdo->query("SELECT dm.member_id, GROUP_CONCAT(rd.title SEPARATOR ', ') AS dirs FROM direction_members dm JOIN research_directions rd ON dm.direction_id=rd.id GROUP BY dm.member_id");
 $memberDirections = [];

--- a/task_affairs.php
+++ b/task_affairs.php
@@ -1,4 +1,5 @@
 <?php
+include 'auth_manager.php';
 include 'header.php';
 $task_id = $_GET['id'] ?? null;
 if(!$task_id){

--- a/task_delete.php
+++ b/task_delete.php
@@ -1,5 +1,5 @@
 <?php
-include 'auth.php';
+include 'auth_manager.php';
 $id = $_GET['id'] ?? null;
 if($id){
     $pdo->prepare('DELETE FROM tasks WHERE id=?')->execute([$id]);

--- a/task_edit.php
+++ b/task_edit.php
@@ -1,4 +1,5 @@
 <?php
+include 'auth_manager.php';
 include 'header.php';
 $id = $_GET['id'] ?? null;
 $task = ['title'=>'','description'=>'','start_date'=>'','status'=>'active'];

--- a/task_member_fill.php
+++ b/task_member_fill.php
@@ -1,5 +1,5 @@
 <?php
-require 'config.php';
+require 'auth_manager.php';
 $task_id = $_GET['task_id'] ?? null;
 if(!$task_id){
     echo 'Invalid task id';

--- a/tasks.php
+++ b/tasks.php
@@ -1,4 +1,6 @@
-<?php include 'header.php';
+<?php
+include 'auth_manager.php';
+include 'header.php';
 $status = $_GET['status'] ?? '';
 if($status){
     $stmt = $pdo->prepare('SELECT * FROM tasks WHERE status=? ORDER BY id DESC');

--- a/todolist.php
+++ b/todolist.php
@@ -1,0 +1,104 @@
+<?php
+include 'header.php';
+$user_id = $_SESSION['role']==='manager' ? $_SESSION['manager_id'] : $_SESSION['member_id'];
+$role = $_SESSION['role'];
+$week_param = $_GET['week'] ?? date('o-\WW');
+if(preg_match('/^(\d{4})-W(\d{2})$/',$week_param,$m)){
+    $dt = new DateTime();
+    $dt->setISODate($m[1], $m[2]);
+    $week_start = $dt->format('Y-m-d');
+} else {
+    $dt = new DateTime();
+    $dt->setISODate(date('o'), date('W'));
+    $week_start = $dt->format('Y-m-d');
+    $week_param = $dt->format('o-\WW');
+}
+$stmt = $pdo->prepare('SELECT * FROM todolist_items WHERE user_id=? AND user_role=? AND week_start=? ORDER BY sort_order');
+$stmt->execute([$user_id,$role,$week_start]);
+$items = [];
+foreach($stmt as $row){
+    $items[$row['category']][$row['day']][] = $row;
+}
+$days = ['mon'=>'周一','tue'=>'周二','wed'=>'周三','thu'=>'周四','fri'=>'周五','sat'=>'周六','sun'=>'周日'];
+?>
+<h2>待办事项</h2>
+<form method="get" class="mb-3">
+  <input type="week" name="week" value="<?= htmlspecialchars($week_param); ?>">
+  <button type="submit" class="btn btn-secondary btn-sm">切换周</button>
+  <a class="btn btn-success btn-sm" href="todolist_export.php?week=<?= urlencode($week_param); ?>">导出</a>
+  <button type="button" class="btn btn-outline-primary btn-sm" onclick="window.print()">打印</button>
+</form>
+<div class="row">
+  <div class="col-md-6">
+    <h3>工作</h3>
+    <?php foreach($days as $k=>$label): ?>
+    <h5><?= $label; ?> <button type="button" class="btn btn-sm btn-outline-success add-item" data-category="work" data-day="<?= $k; ?>">+</button></h5>
+    <ul class="list-group mb-3 todolist" data-category="work" data-day="<?= $k; ?>">
+      <?php if(!empty($items['work'][$k])): foreach($items['work'][$k] as $it): ?>
+      <li class="list-group-item d-flex align-items-center" data-id="<?= $it['id']; ?>">
+        <input type="checkbox" class="form-check-input me-2 item-done" <?= $it['is_done']?'checked':''; ?>>
+        <input type="text" class="form-control item-content" value="<?= htmlspecialchars($it['content']); ?>">
+        <button class="btn btn-sm btn-danger ms-2 delete-item">&times;</button>
+      </li>
+      <?php endforeach; endif; ?>
+    </ul>
+    <?php endforeach; ?>
+  </div>
+  <div class="col-md-6">
+    <h3>私人</h3>
+    <?php foreach($days as $k=>$label): ?>
+    <h5><?= $label; ?> <button type="button" class="btn btn-sm btn-outline-success add-item" data-category="personal" data-day="<?= $k; ?>">+</button></h5>
+    <ul class="list-group mb-3 todolist" data-category="personal" data-day="<?= $k; ?>">
+      <?php if(!empty($items['personal'][$k])): foreach($items['personal'][$k] as $it): ?>
+      <li class="list-group-item d-flex align-items-center" data-id="<?= $it['id']; ?>">
+        <input type="checkbox" class="form-check-input me-2 item-done" <?= $it['is_done']?'checked':''; ?>>
+        <input type="text" class="form-control item-content" value="<?= htmlspecialchars($it['content']); ?>">
+        <button class="btn btn-sm btn-danger ms-2 delete-item">&times;</button>
+      </li>
+      <?php endforeach; endif; ?>
+    </ul>
+    <?php endforeach; ?>
+    <h3>长期 <button type="button" class="btn btn-sm btn-outline-success add-item" data-category="longterm" data-day="">+</button></h3>
+    <ul class="list-group mb-3 todolist" data-category="longterm" data-day="">
+      <?php if(!empty($items['longterm'][''])): foreach($items['longterm'][''] as $it): ?>
+      <li class="list-group-item d-flex align-items-center" data-id="<?= $it['id']; ?>">
+        <input type="checkbox" class="form-check-input me-2 item-done" <?= $it['is_done']?'checked':''; ?>>
+        <input type="text" class="form-control item-content" value="<?= htmlspecialchars($it['content']); ?>">
+        <button class="btn btn-sm btn-danger ms-2 delete-item">&times;</button>
+      </li>
+      <?php endforeach; endif; ?>
+    </ul>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.14.0/Sortable.min.js"></script>
+<script>
+function saveItem(li){
+  const id=li.dataset.id;
+  const content=li.querySelector('.item-content').value;
+  const done=li.querySelector('.item-done').checked;
+  const list=li.parentElement;
+  const data={action:'update',id:id,content:content,is_done:done,category:list.dataset.category,day:list.dataset.day,week_start:'<?= $week_start; ?>'};
+  fetch('todolist_save.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)}).then(r=>r.json()).then(j=>{if(!id)li.dataset.id=j.id;});
+}
+function attach(li){
+  li.querySelector('.item-content').addEventListener('input',()=>saveItem(li));
+  li.querySelector('.item-done').addEventListener('change',()=>saveItem(li));
+  li.querySelector('.delete-item').addEventListener('click',()=>{fetch('todolist_save.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'delete',id:li.dataset.id})}).then(()=>li.remove());});
+}
+document.querySelectorAll('.todolist').forEach(list=>{
+  Sortable.create(list,{animation:150,onEnd:function(){const order=Array.from(list.children).map((li,i)=>({id:li.dataset.id,position:i}));fetch('todolist_save.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({action:'order',order:order})});}});
+  list.querySelectorAll('li').forEach(attach);
+});
+document.querySelectorAll('.add-item').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const list=document.querySelector(`.todolist[data-category='${btn.dataset.category}'][data-day='${btn.dataset.day}']`);
+    const li=document.createElement('li');
+    li.className='list-group-item d-flex align-items-center';
+    li.innerHTML=`<input type="checkbox" class="form-check-input me-2 item-done"><input type="text" class="form-control item-content"><button class="btn btn-sm btn-danger ms-2 delete-item">&times;</button>`;
+    list.appendChild(li);
+    attach(li);
+    saveItem(li);
+  });
+});
+</script>
+<?php include 'footer.php'; ?>

--- a/todolist_export.php
+++ b/todolist_export.php
@@ -1,0 +1,25 @@
+<?php
+require 'auth.php';
+$user_id = $_SESSION['role']==='manager' ? $_SESSION['manager_id'] : $_SESSION['member_id'];
+$role = $_SESSION['role'];
+$week_param = $_GET['week'] ?? date('o-\WW');
+if(preg_match('/^(\d{4})-W(\d{2})$/',$week_param,$m)){
+    $dt = new DateTime();
+    $dt->setISODate($m[1], $m[2]);
+    $week_start = $dt->format('Y-m-d');
+} else {
+    $dt = new DateTime();
+    $dt->setISODate(date('o'), date('W'));
+    $week_start = $dt->format('Y-m-d');
+    $week_param = $dt->format('o-\WW');
+}
+$stmt = $pdo->prepare('SELECT category, day, content, is_done FROM todolist_items WHERE user_id=? AND user_role=? AND week_start=? ORDER BY category, day, sort_order');
+$stmt->execute([$user_id,$role,$week_start]);
+header('Content-Type: text/csv; charset=UTF-8');
+header('Content-Disposition: attachment; filename="todolist.csv"');
+echo "category,day,content,is_done\n";
+while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
+    $content = str_replace('"','""',$row['content']);
+    echo $row['category'].",".$row['day'].",\"$content\",".$row['is_done']."\n";
+}
+?>

--- a/todolist_save.php
+++ b/todolist_save.php
@@ -1,0 +1,35 @@
+<?php
+require 'auth.php';
+$user_id = $_SESSION['role']==='manager' ? $_SESSION['manager_id'] : $_SESSION['member_id'];
+$role = $_SESSION['role'];
+$data = json_decode(file_get_contents('php://input'), true);
+$action = $data['action'] ?? 'update';
+if($action === 'update'){
+    $id = $data['id'] ?? null;
+    $content = $data['content'] ?? '';
+    $is_done = !empty($data['is_done']) ? 1 : 0;
+    $category = $data['category'];
+    $day = $data['day'] ?: null;
+    $week_start = $data['week_start'];
+    if($id){
+        $stmt = $pdo->prepare('UPDATE todolist_items SET content=?, is_done=? WHERE id=? AND user_id=? AND user_role=?');
+        $stmt->execute([$content,$is_done,$id,$user_id,$role]);
+        echo json_encode(['id'=>$id]);
+    } else {
+        $stmt = $pdo->prepare('INSERT INTO todolist_items (user_id,user_role,week_start,category,day,content,is_done,sort_order) VALUES (?,?,?,?,?,?,?,0)');
+        $stmt->execute([$user_id,$role,$week_start,$category,$day,$content,$is_done]);
+        echo json_encode(['id'=>$pdo->lastInsertId()]);
+    }
+} elseif($action === 'delete'){
+    $id = $data['id'];
+    $stmt = $pdo->prepare('DELETE FROM todolist_items WHERE id=? AND user_id=? AND user_role=?');
+    $stmt->execute([$id,$user_id,$role]);
+    echo json_encode(['status'=>'ok']);
+} elseif($action === 'order'){
+    foreach($data['order'] as $o){
+        $stmt = $pdo->prepare('UPDATE todolist_items SET sort_order=? WHERE id=? AND user_id=? AND user_role=?');
+        $stmt->execute([$o['position'],$o['id'],$user_id,$role]);
+    }
+    echo json_encode(['status'=>'ok']);
+}
+?>

--- a/workload.php
+++ b/workload.php
@@ -1,5 +1,5 @@
 <?php
-include 'auth.php';
+include 'auth_manager.php';
 $start = $_GET['start'] ?? '';
 $end = $_GET['end'] ?? '';
 $report = [];


### PR DESCRIPTION
## Summary
- allow members to log in with name and ID number and separate manager/member interfaces
- show navigation items based on role and restrict manager-only pages
- add personal weekly todolist with export and print support

## Testing
- `php -l login.php auth.php auth_manager.php header.php members.php projects.php directions.php tasks.php workload.php account.php task_affairs.php task_delete.php task_edit.php task_member_fill.php affair_add.php affair_delete.php affair_edit.php todolist.php todolist_save.php todolist_export.php`

------
https://chatgpt.com/codex/tasks/task_e_689d4bf082a8832a9ddeccbf1dce55f6