### PR TITLE
Improve localization and todolist export

### DIFF
--- a/account.php
+++ b/account.php
@@ -10,7 +10,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
         $new = $_POST['new_password'] ?? '';
         $confirm = $_POST['confirm_password'] ?? '';
         if($new !== $confirm){
-            $password_msg = 'New passwords do not match';
+            $password_msg = 'account.msg.password_mismatch';
         } else {
             $stmt = $pdo->prepare('SELECT password FROM managers WHERE id = ?');
             $stmt->execute([$_SESSION['manager_id']]);
@@ -18,9 +18,9 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             if($manager && password_verify($current, $manager['password'])){
                 $stmt = $pdo->prepare('UPDATE managers SET password = ? WHERE id = ?');
                 $stmt->execute([password_hash($new, PASSWORD_DEFAULT), $_SESSION['manager_id']]);
-                $password_msg = 'Password updated successfully';
+                $password_msg = 'account.msg.password_updated';
             } else {
-                $password_msg = 'Current password is incorrect';
+                $password_msg = 'account.msg.current_incorrect';
             }
         }
     } elseif($_POST['action'] === 'add_manager'){
@@ -30,9 +30,9 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
             try{
                 $stmt = $pdo->prepare('INSERT INTO managers (username, password) VALUES (?, ?)');
                 $stmt->execute([$username, password_hash($password, PASSWORD_DEFAULT)]);
-                $add_msg = 'Manager added';
+                $add_msg = 'account.msg.manager_added';
             } catch(PDOException $e){
-                $add_msg = 'Error adding manager';
+                $add_msg = 'account.msg.manager_add_error';
             }
         }
     }
@@ -44,7 +44,7 @@ include 'header.php';
 <div class="row">
   <div class="col-md-6">
     <h3 data-i18n="account.change_password">Change Password</h3>
-    <?php if($password_msg): ?><div class="alert alert-info"><?php echo htmlspecialchars($password_msg); ?></div><?php endif; ?>
+    <?php if($password_msg): ?><div class="alert alert-info" data-i18n="<?= $password_msg; ?>"></div><?php endif; ?>
     <form method="post">
       <input type="hidden" name="action" value="change_password">
       <div class="mb-3">
@@ -64,7 +64,7 @@ include 'header.php';
   </div>
   <div class="col-md-6">
     <h3 data-i18n="account.add_manager">Add Manager</h3>
-    <?php if($add_msg): ?><div class="alert alert-info"><?php echo htmlspecialchars($add_msg); ?></div><?php endif; ?>
+    <?php if($add_msg): ?><div class="alert alert-info" data-i18n="<?= $add_msg; ?>"></div><?php endif; ?>
     <form method="post">
       <input type="hidden" name="action" value="add_manager">
       <div class="mb-3">

--- a/app.js
+++ b/app.js
@@ -58,6 +58,15 @@ const translations = {
     'projects.action_edit': 'Edit',
     'projects.action_members': 'Members',
     'projects.action_delete': 'Delete',
+    'projects.toggle_details': 'Show Member Details',
+    'projects.participation_title': 'Project Participation',
+    'projects.participation.member': 'Member',
+    'projects.participation.projects': 'Projects',
+    'projects.status.todo': 'Todo',
+    'projects.status.ongoing': 'Ongoing',
+    'projects.status.paused': 'Paused',
+    'projects.status.finished': 'Finished',
+    'projects.no_direction': 'No direction',
     'index.title': 'Dashboard',
     'index.info': 'Use the navigation bar to manage team members, projects, tasks, and workload reports.',
     'theme.dark': 'Dark',
@@ -102,7 +111,42 @@ const translations = {
     'todolist.days.thu': 'Thu',
     'todolist.days.fri': 'Fri',
     'todolist.days.sat': 'Sat',
-    'todolist.days.sun': 'Sun'
+    'todolist.days.sun': 'Sun',
+    'tasks.title': 'Tasks Assignment',
+    'tasks.add': 'New Task',
+    'tasks.filter_all': 'All Status',
+    'tasks.filter.active': 'Active',
+    'tasks.filter.paused': 'Paused',
+    'tasks.filter.finished': 'Finished',
+    'tasks.filter.button': 'Filter',
+    'tasks.table_title': 'Title',
+    'tasks.table_start': 'Start',
+    'tasks.table_status': 'Status',
+    'tasks.table_actions': 'Actions',
+    'tasks.action_edit': 'Edit',
+    'tasks.action_affairs': 'Affairs',
+    'tasks.action_fill': 'Self Fill',
+    'tasks.action_delete': 'Delete',
+    'tasks.status.active': 'Active',
+    'tasks.status.paused': 'Paused',
+    'tasks.status.finished': 'Finished',
+    'tasks.confirm.delete': 'Delete task?',
+    'workload.title': 'Workload Report',
+    'workload.error.range': 'End date must be after start date',
+    'workload.label.start': 'Start Date',
+    'workload.label.end': 'End Date',
+    'workload.generate': 'Generate',
+    'workload.export': 'Export to EXCEL',
+    'workload.table.rank': 'Rank',
+    'workload.table.campus_id': 'Campus ID',
+    'workload.table.name': 'Name',
+    'workload.table.task_detail': 'Task Detail',
+    'workload.table.task_hours': 'Task Hours',
+    'account.msg.password_mismatch': 'New passwords do not match',
+    'account.msg.password_updated': 'Password updated successfully',
+    'account.msg.current_incorrect': 'Current password is incorrect',
+    'account.msg.manager_added': 'Manager added',
+    'account.msg.manager_add_error': 'Error adding manager'
   },
   zh: {
     'nav.home': '团队管理',
@@ -163,6 +207,15 @@ const translations = {
     'projects.action_edit': '编辑',
     'projects.action_members': '成员',
     'projects.action_delete': '删除',
+    'projects.toggle_details': '显示成员详情',
+    'projects.participation_title': '项目参与人员情况',
+    'projects.participation.member': '成员',
+    'projects.participation.projects': '参与项目',
+    'projects.status.todo': '待办',
+    'projects.status.ongoing': '进行中',
+    'projects.status.paused': '暂停',
+    'projects.status.finished': '已完成',
+    'projects.no_direction': '无研究方向',
     'index.title': '仪表板',
     'index.info': '使用导航栏来管理团队成员、项目、任务和工作量报告。',
     'theme.dark': '暗色',
@@ -207,7 +260,42 @@ const translations = {
     'todolist.days.thu': '周四',
     'todolist.days.fri': '周五',
     'todolist.days.sat': '周六',
-    'todolist.days.sun': '周日'
+    'todolist.days.sun': '周日',
+    'tasks.title': '任务指派',
+    'tasks.add': '新建任务',
+    'tasks.filter_all': '所有状态',
+    'tasks.filter.active': '进行中',
+    'tasks.filter.paused': '暂停',
+    'tasks.filter.finished': '已结束',
+    'tasks.filter.button': '筛选',
+    'tasks.table_title': '任务标题',
+    'tasks.table_start': '开始日期',
+    'tasks.table_status': '状态',
+    'tasks.table_actions': '操作',
+    'tasks.action_edit': '编辑信息',
+    'tasks.action_affairs': '下辖具体事务',
+    'tasks.action_fill': '请成员自己填',
+    'tasks.action_delete': '删除',
+    'tasks.status.active': '进行中',
+    'tasks.status.paused': '暂停',
+    'tasks.status.finished': '已结束',
+    'tasks.confirm.delete': '删除任务？',
+    'workload.title': '工作量统计报表',
+    'workload.error.range': '报表截止时间必须晚于起始时间',
+    'workload.label.start': '报表起始时间',
+    'workload.label.end': '报表截止时间',
+    'workload.generate': '生成报表',
+    'workload.export': '导出为EXCEL',
+    'workload.table.rank': '排名',
+    'workload.table.campus_id': '一卡通号',
+    'workload.table.name': '姓名',
+    'workload.table.task_detail': '具体任务',
+    'workload.table.task_hours': '任务投入时长',
+    'account.msg.password_mismatch': '两次新密码不一致',
+    'account.msg.password_updated': '密码更新成功',
+    'account.msg.current_incorrect': '当前密码错误',
+    'account.msg.manager_added': '管理员已添加',
+    'account.msg.manager_add_error': '添加管理员出错'
   }
 };
 
@@ -223,6 +311,13 @@ function applyTranslations() {
     const text = translations[lang][key];
     if(text) {
       el.textContent = text;
+    }
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(el => {
+    const key = el.getAttribute('data-i18n-title');
+    const text = translations[lang][key];
+    if(text) {
+      el.setAttribute('title', text);
     }
   });
   const langToggle = document.getElementById('langToggle');

--- a/footer.php
+++ b/footer.php
@@ -22,15 +22,14 @@ function applyTeamName() {
   const name = typeof TEAM_NAME === 'string' ? TEAM_NAME : (TEAM_NAME[lang] || '');
   if (!name) return;
   const regex = /(团队|Team)/g;
-  if (regex.test(document.title)) {
-    document.title = document.title.replace(regex, name + '$1');
-  }
+  const replacer = (match, p1, offset, str) => {
+    return str.slice(Math.max(0, offset - name.length), offset) === name ? match : name + match;
+  };
+  document.title = document.title.replace(regex, replacer);
   (function walk(node) {
     node.childNodes.forEach(child => {
       if (child.nodeType === Node.TEXT_NODE) {
-        if (regex.test(child.textContent)) {
-          child.textContent = child.textContent.replace(regex, name + '$1');
-        }
+        child.textContent = child.textContent.replace(regex, replacer);
       } else {
         walk(child);
       }

--- a/projects.php
+++ b/projects.php
@@ -53,7 +53,7 @@ if($status){
 </form>
 <div class="form-check form-switch mb-3">
   <input class="form-check-input" type="checkbox" id="detailToggle" checked>
-  <label class="form-check-label" for="detailToggle">显示成员详情</label>
+  <label class="form-check-label" for="detailToggle" data-i18n="projects.toggle_details">Show Member Details</label>
 </div>
 <table class="table table-bordered">
   <thead>
@@ -85,7 +85,7 @@ if($status){
     <td>
       <?php if($memberList): ?>
         <?php foreach($memberList as $idx=>$m): ?>
-          <span class="member-name" data-bs-toggle="tooltip" title="<?= htmlspecialchars($memberDirections[$m['id']] ?? '无研究方向'); ?>">
+          <span class="member-name" data-bs-toggle="tooltip" title="<?= htmlspecialchars($memberDirections[$m['id']] ?? '') ?>"<?php if(empty($memberDirections[$m['id']])) echo ' data-i18n-title="projects.no_direction"'; ?>>
             <?= htmlspecialchars($m['name']); ?>
             <span class="member-detail text-muted">(<?= htmlspecialchars($m['degree']); ?>,<?= htmlspecialchars($m['year']); ?>)</span>
           </span><?= $idx < count($memberList)-1 ? ', ' : ''; ?>
@@ -96,7 +96,7 @@ if($status){
     </td>
     <td><?= htmlspecialchars($p['begin_date']); ?></td>
     <td><?= htmlspecialchars($p['end_date']); ?></td>
-    <td><?= htmlspecialchars($p['status']); ?></td>
+    <td data-i18n="projects.status.<?= htmlspecialchars($p['status']); ?>"><?= htmlspecialchars($p['status']); ?></td>
     <td>
       <a class="btn btn-sm btn-primary" href="project_edit.php?id=<?= $p['id']; ?>" data-i18n="projects.action_edit">Edit</a>
       <a class="btn btn-sm btn-warning" href="project_members.php?id=<?= $p['id']; ?>" data-i18n="projects.action_members">Members</a>
@@ -106,15 +106,15 @@ if($status){
   <?php endforeach; ?>
   </tbody>
 </table>
-<h3 class="mt-4">项目参与人员情况</h3>
+<h3 class="mt-4" data-i18n="projects.participation_title">项目参与人员情况</h3>
 <table class="table table-bordered">
-  <tr><th>成员</th><th>参与项目</th></tr>
+  <tr><th data-i18n="projects.participation.member">成员</th><th data-i18n="projects.participation.projects">参与项目</th></tr>
   <?php
   $memberProjects = $pdo->query("SELECT m.name, m.degree_pursuing, m.year_of_join, GROUP_CONCAT(p.title ORDER BY l.sort_order SEPARATOR ', ') AS proj FROM members m LEFT JOIN project_member_log l ON m.id=l.member_id AND l.exit_time IS NULL LEFT JOIN projects p ON l.project_id=p.id WHERE m.status != 'exited' GROUP BY m.id ORDER BY m.sort_order")->fetchAll();
   foreach($memberProjects as $mp): ?>
   <tr>
     <td><?= htmlspecialchars($mp["name"]); ?><span class="member-detail text-muted">(<?= htmlspecialchars($mp["degree_pursuing"]); ?>,<?= htmlspecialchars($mp["year_of_join"]); ?>)</span></td>
-    <td><?= $mp['proj'] ? htmlspecialchars($mp['proj']) : '<span style="color:red"><em>暂无</em></span>'; ?></td>
+    <td><?= $mp['proj'] ? htmlspecialchars($mp['proj']) : '<span style="color:red"><em data-i18n="directions.none">None</em></span>'; ?></td>
   </tr>
   <?php endforeach; ?>
 </table>

--- a/tasks.php
+++ b/tasks.php
@@ -11,36 +11,47 @@ if($status){
 }
 ?>
 <div class="d-flex justify-content-between mb-3">
-  <h2>任务指派</h2>
-  <a class="btn btn-success" href="task_edit.php">新建任务</a>
+  <h2 data-i18n="tasks.title">Tasks Assignment</h2>
+  <a class="btn btn-success" href="task_edit.php" data-i18n="tasks.add">New Task</a>
 </div>
 <form class="row g-3 mb-3" method="get">
   <div class="col-auto">
     <select name="status" class="form-select">
-      <option value="">所有状态</option>
-      <option value="active" <?= $status=='active'?'selected':''; ?>>进行中</option>
-      <option value="paused" <?= $status=='paused'?'selected':''; ?>>暂停</option>
-      <option value="finished" <?= $status=='finished'?'selected':''; ?>>已结束</option>
+      <option value="" data-i18n="tasks.filter_all">All Status</option>
+      <option value="active" <?= $status=='active'?'selected':''; ?> data-i18n="tasks.filter.active">Active</option>
+      <option value="paused" <?= $status=='paused'?'selected':''; ?> data-i18n="tasks.filter.paused">Paused</option>
+      <option value="finished" <?= $status=='finished'?'selected':''; ?> data-i18n="tasks.filter.finished">Finished</option>
     </select>
   </div>
   <div class="col-auto">
-    <button type="submit" class="btn btn-primary">筛选</button>
+    <button type="submit" class="btn btn-primary" data-i18n="tasks.filter.button">Filter</button>
   </div>
 </form>
 <table class="table table-bordered">
-<tr><th>任务标题</th><th>开始日期</th><th>状态</th><th>操作</th></tr>
+<tr><th data-i18n="tasks.table_title">Title</th><th data-i18n="tasks.table_start">Start</th><th data-i18n="tasks.table_status">Status</th><th data-i18n="tasks.table_actions">Actions</th></tr>
 <?php foreach($tasks as $t): ?>
 <tr>
   <td><?= htmlspecialchars($t['title']); ?></td>
   <td><?= htmlspecialchars($t['start_date']); ?></td>
-  <td><?= htmlspecialchars($t['status']); ?></td>
+  <td data-i18n="tasks.status.<?= htmlspecialchars($t['status']); ?>"><?= htmlspecialchars($t['status']); ?></td>
   <td>
-    <a class="btn btn-sm btn-primary" href="task_edit.php?id=<?= $t['id']; ?>">编辑信息</a>
-    <a class="btn btn-sm btn-warning" href="task_affairs.php?id=<?= $t['id']; ?>">下辖具体事务</a>
-    <button type="button" class="btn btn-sm btn-info qr-btn" data-url="task_member_fill.php?task_id=<?= $t['id']; ?>">请成员自己填</button>
-    <a class="btn btn-sm btn-danger" href="task_delete.php?id=<?= $t['id']; ?>" onclick="return doubleConfirm('Delete task?');">删除</a>
+    <a class="btn btn-sm btn-primary" href="task_edit.php?id=<?= $t['id']; ?>" data-i18n="tasks.action_edit">Edit</a>
+    <a class="btn btn-sm btn-warning" href="task_affairs.php?id=<?= $t['id']; ?>" data-i18n="tasks.action_affairs">Affairs</a>
+    <button type="button" class="btn btn-sm btn-info qr-btn" data-url="task_member_fill.php?task_id=<?= $t['id']; ?>" data-i18n="tasks.action_fill">Self Fill</button>
+    <a class="btn btn-sm btn-danger delete-task" href="task_delete.php?id=<?= $t['id']; ?>" data-i18n="tasks.action_delete">Delete</a>
   </td>
 </tr>
 <?php endforeach; ?>
 </table>
+<script>
+document.addEventListener('DOMContentLoaded',()=>{
+  document.querySelectorAll('.delete-task').forEach(link=>{
+    link.addEventListener('click',e=>{
+      const lang=document.documentElement.lang||'en';
+      const msg=translations[lang]['tasks.confirm.delete'];
+      if(!doubleConfirm(msg)) e.preventDefault();
+    });
+  });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/todolist.php
+++ b/todolist.php
@@ -39,7 +39,7 @@ $days = ['mon'=>'周一','tue'=>'周二','wed'=>'周三','thu'=>'周四','fri'=>
   <input type="week" name="week" value="<?= htmlspecialchars($week_param); ?>">
   <button type="submit" class="btn btn-secondary btn-sm" data-i18n="todolist.switch_week">切换周</button>
   <a class="btn btn-success btn-sm" href="todolist_export.php?week=<?= urlencode($week_param); ?>" data-i18n="todolist.export">导出</a>
-  <button type="button" class="btn btn-outline-primary btn-sm" onclick="window.print()" data-i18n="todolist.print">打印</button>
+  <button type="button" class="btn btn-outline-primary btn-sm" onclick="printTodoList()" data-i18n="todolist.print">打印</button>
 </form>
 <div class="row">
   <div class="col-md-6">
@@ -113,5 +113,31 @@ document.querySelectorAll('.add-item').forEach(btn=>{
     saveItem(li);
   });
 });
+
+function printTodoList(){
+  const lang=document.documentElement.lang||'en';
+  let html='<html><head><title>'+document.title+'</title><style>body{font-family:sans-serif;padding:10mm;}h3{margin-top:10mm;}ul{list-style:none;padding-left:0;}li{margin:4px 0;}li.done{text-decoration:line-through;color:#888;}</style></head><body>';
+  document.querySelectorAll('.todolist').forEach(list=>{
+    if(!list.children.length) return;
+    const catKey='todolist.category.'+list.dataset.category;
+    const dayKey=list.dataset.day? 'todolist.days.'+list.dataset.day : '';
+    let header=translations[lang][catKey]||'';
+    if(dayKey) header+=' - '+translations[lang][dayKey];
+    html+='<h3>'+header+'</h3><ul>';
+    list.querySelectorAll('li').forEach(li=>{
+      const content=li.querySelector('.item-content').value;
+      const done=li.querySelector('.item-done').checked;
+      html+='<li class="'+(done?'done':'')+'">'+content+'</li>';
+    });
+    html+='</ul>';
+  });
+  html+='</body></html>';
+  const w=window.open('','_blank');
+  w.document.write(html);
+  w.document.close();
+  w.focus();
+  w.print();
+  w.close();
+}
 </script>
 <?php include 'footer.php'; ?>

--- a/todolist_export.php
+++ b/todolist_export.php
@@ -17,6 +17,7 @@ $stmt = $pdo->prepare('SELECT category, day, content, is_done FROM todolist_item
 $stmt->execute([$user_id,$role,$week_start]);
 header('Content-Type: text/csv; charset=UTF-8');
 header('Content-Disposition: attachment; filename="todolist.csv"');
+echo "\xEF\xBB\xBF"; // UTF-8 BOM for Excel
 echo "category,day,content,is_done\n";
 while($row = $stmt->fetch(PDO::FETCH_ASSOC)){
     $content = str_replace('"','""',$row['content']);


### PR DESCRIPTION
## Summary
- Prevent duplicate organization names by making `applyTeamName` idempotent
- Expand i18n coverage for tasks, projects, workload and account pages
- Add printable todo list view and proper UTF-8 CSV export

## Testing
- `php -l footer.php projects.php tasks.php workload.php account.php todolist_export.php todolist.php`
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_689d6c0d4f68832abbb7f740f7f00e68