### PR TITLE
Improve login UX, add team name, and extend translations

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,6 +188,29 @@ const translations = {
     'tasks.status.paused': 'Paused',
     'tasks.status.finished': 'Finished',
     'tasks.confirm.delete': 'Delete task?',
+    'task_affairs.title_prefix': 'Task Affairs - ',
+    'task_affairs.table_description': 'Description',
+    'task_affairs.table_members': 'Members',
+    'task_affairs.table_start': 'Start Date',
+    'task_affairs.table_end': 'End Date',
+    'task_affairs.table_days': 'Days',
+    'task_affairs.table_actions': 'Actions',
+    'task_affairs.action_edit': 'Edit',
+    'task_affairs.action_delete': 'Delete',
+    'task_affairs.edit_title': 'Edit Affair',
+    'task_affairs.label_description': 'Description',
+    'task_affairs.label_start': 'Start Date',
+    'task_affairs.label_end': 'End Date',
+    'task_affairs.save': 'Save',
+    'task_affairs.cancel': 'Cancel',
+    'task_affairs.new_title': 'New Affair',
+    'task_affairs.label_members': 'Members (hold Ctrl to select multiple)',
+    'task_affairs.add': 'Add Affair',
+    'task_affairs.back': 'Back',
+    'task_affairs.error.range': 'End date must not be earlier than start date',
+    'task_affairs.workload_prefix': 'Workload: ',
+    'task_affairs.workload_suffix': ' days',
+    'task_affairs.confirm.delete': 'Delete affair?',
     'workload.title': 'Workload Report',
     'workload.error.range': 'End date must be after start date',
     'workload.label.start': 'Start Date',
@@ -394,6 +417,29 @@ const translations = {
     'tasks.status.paused': '暂停',
     'tasks.status.finished': '已结束',
     'tasks.confirm.delete': '删除任务？',
+    'task_affairs.title_prefix': '下辖具体事务 - ',
+    'task_affairs.table_description': '具体事务描述',
+    'task_affairs.table_members': '负责成员',
+    'task_affairs.table_start': '起始日期',
+    'task_affairs.table_end': '结束日期',
+    'task_affairs.table_days': '天数',
+    'task_affairs.table_actions': '操作',
+    'task_affairs.action_edit': '编辑',
+    'task_affairs.action_delete': '删除',
+    'task_affairs.edit_title': '编辑事务',
+    'task_affairs.label_description': '具体事务描述',
+    'task_affairs.label_start': '起始日期',
+    'task_affairs.label_end': '结束日期',
+    'task_affairs.save': '保存',
+    'task_affairs.cancel': '取消',
+    'task_affairs.new_title': '新建具体事务',
+    'task_affairs.label_members': '负责成员 (按住Ctrl键点选多个人)',
+    'task_affairs.add': '新增事务',
+    'task_affairs.back': '返回',
+    'task_affairs.error.range': '结束日期必须不早于起始日期',
+    'task_affairs.workload_prefix': '本次事务工作量：',
+    'task_affairs.workload_suffix': ' 天',
+    'task_affairs.confirm.delete': '删除事务?',
     'workload.title': '工作量统计报表',
     'workload.error.range': '报表截止时间必须晚于起始时间',
     'workload.label.start': '报表起始时间',
@@ -451,24 +497,30 @@ function applyTheme() {
   document.documentElement.setAttribute('data-bs-theme', theme);
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function initApp() {
   applyTheme();
   applyTranslations();
 
-  document.getElementById('langToggle')?.addEventListener('click', () => {
-    const current = localStorage.getItem('lang') || 'en';
-    const next = current === 'en' ? 'zh' : 'en';
-    localStorage.setItem('lang', next);
-    applyTranslations();
-  });
+  const langBtn = document.getElementById('langToggle');
+  if (langBtn) {
+    langBtn.addEventListener('click', () => {
+      const current = localStorage.getItem('lang') || 'en';
+      const next = current === 'en' ? 'zh' : 'en';
+      localStorage.setItem('lang', next);
+      applyTranslations();
+    });
+  }
 
-  document.getElementById('themeToggle')?.addEventListener('click', () => {
-    const current = localStorage.getItem('theme') || 'light';
-    const next = current === 'light' ? 'dark' : 'light';
-    localStorage.setItem('theme', next);
-    applyTheme();
-    applyTranslations();
-  });
+  const themeBtn = document.getElementById('themeToggle');
+  if (themeBtn) {
+    themeBtn.addEventListener('click', () => {
+      const current = localStorage.getItem('theme') || 'light';
+      const next = current === 'light' ? 'dark' : 'light';
+      localStorage.setItem('theme', next);
+      applyTheme();
+      applyTranslations();
+    });
+  }
 
   document.querySelectorAll('.qr-btn').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -482,4 +534,10 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initApp);
+} else {
+  initApp();
+}

--- a/footer.php
+++ b/footer.php
@@ -13,30 +13,7 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="app.js"></script>
 <script src="team_name.js"></script>
-<script>
-function applyTeamName() {
-  if (typeof TEAM_NAME === 'undefined') return;
-  const lang = localStorage.getItem('lang') || document.documentElement.lang || 'en';
-  const name = typeof TEAM_NAME === 'string' ? TEAM_NAME : (TEAM_NAME[lang] || '');
-  if (!name) return;
-  const regex = /(团队|Team)/g;
-  const replacer = (match, p1, offset, str) => {
-    return str.slice(Math.max(0, offset - name.length), offset) === name ? match : name + match;
-  };
-  document.title = document.title.replace(regex, replacer);
-  (function walk(node) {
-    node.childNodes.forEach(child => {
-      if (child.nodeType === Node.TEXT_NODE) {
-        child.textContent = child.textContent.replace(regex, replacer);
-      } else {
-        walk(child);
-      }
-    });
-  })(document.body);
-}
-document.addEventListener('DOMContentLoaded', applyTeamName);
-</script>
+<script src="app.js"></script>
 </body>
 </html>

--- a/login.php
+++ b/login.php
@@ -57,6 +57,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
     <button id="langToggle" class="btn btn-outline-secondary btn-sm">中文</button>
     <button id="themeToggle" class="btn btn-outline-secondary btn-sm" data-i18n="theme.dark">Dark</button>
   </div>
+  <h2 class="text-center mb-4" data-i18n="header.title">Team Management Platform</h2>
   <div class="row justify-content-center">
     <div class="col-md-4">
       <div class="card">
@@ -123,6 +124,7 @@ document.addEventListener('DOMContentLoaded',function(){
   });
 });
 </script>
+<script src="team_name.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/task_affairs.php
+++ b/task_affairs.php
@@ -14,9 +14,16 @@ $affairs_stmt->execute([$task_id]);
 $affairs = $affairs_stmt->fetchAll();
 $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 'exited' ORDER BY name")->fetchAll();
 ?>
-<h2>下辖具体事务 - <?php echo htmlspecialchars($task['title']); ?></h2>
+<h2><span data-i18n="task_affairs.title_prefix">Task Affairs - </span><?php echo htmlspecialchars($task['title']); ?></h2>
 <table class="table table-bordered">
-<tr><th>具体事务描述</th><th>负责成员</th><th>起始日期</th><th>结束日期</th><th>天数</th><th>操作</th></tr>
+<tr>
+  <th data-i18n="task_affairs.table_description">Description</th>
+  <th data-i18n="task_affairs.table_members">Members</th>
+  <th data-i18n="task_affairs.table_start">Start Date</th>
+  <th data-i18n="task_affairs.table_end">End Date</th>
+  <th data-i18n="task_affairs.table_days">Days</th>
+  <th data-i18n="task_affairs.table_actions">Actions</th>
+</tr>
 <?php foreach($affairs as $a): ?>
 <?php $days = (strtotime($a['end_time']) - strtotime($a['start_time']))/86400; ?>
 <tr>
@@ -26,8 +33,8 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
   <td><?= htmlspecialchars(date('Y-m-d', strtotime($a['end_time'] . ' -1 day'))); ?></td>
   <td><?= htmlspecialchars($days); ?></td>
   <td>
-    <button type="button" class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal<?= $a['id']; ?>">编辑</button>
-    <a class="btn btn-sm btn-danger" href="affair_delete.php?id=<?= $a['id']; ?>&task_id=<?= $task_id; ?>" onclick="return doubleConfirm('Delete affair?');">删除</a>
+    <button type="button" class="btn btn-sm btn-secondary" data-bs-toggle="modal" data-bs-target="#editModal<?= $a['id']; ?>" data-i18n="task_affairs.action_edit">Edit</button>
+    <a class="btn btn-sm btn-danger delete-affair" href="affair_delete.php?id=<?= $a['id']; ?>&task_id=<?= $task_id; ?>" data-i18n="task_affairs.action_delete">Delete</a>
   </td>
 </tr>
 <?php endforeach; ?>
@@ -39,28 +46,28 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
     <div class="modal-content">
       <form method="post" action="affair_edit.php" class="edit-affair-form">
         <div class="modal-header">
-          <h5 class="modal-title">编辑事务</h5>
+          <h5 class="modal-title" data-i18n="task_affairs.edit_title">Edit Affair</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
           <input type="hidden" name="id" value="<?= $a['id']; ?>">
           <input type="hidden" name="task_id" value="<?= $task_id; ?>">
           <div class="mb-3">
-            <label class="form-label">具体事务描述</label>
+            <label class="form-label" data-i18n="task_affairs.label_description">Description</label>
             <textarea name="description" class="form-control" rows="2" required><?= htmlspecialchars($a['description']); ?></textarea>
           </div>
           <div class="mb-3">
-            <label class="form-label">起始日期</label>
+            <label class="form-label" data-i18n="task_affairs.label_start">Start Date</label>
             <input type="date" name="start_time" class="form-control edit-start" required value="<?= date('Y-m-d', strtotime($a['start_time'])); ?>">
           </div>
           <div class="mb-3">
-            <label class="form-label">结束日期</label>
+            <label class="form-label" data-i18n="task_affairs.label_end">End Date</label>
             <input type="date" name="end_time" class="form-control edit-end" required value="<?= date('Y-m-d', strtotime($a['end_time'] . ' -1 day')); ?>">
           </div>
         </div>
         <div class="modal-footer">
-          <button type="submit" class="btn btn-primary">保存</button>
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+          <button type="submit" class="btn btn-primary" data-i18n="task_affairs.save">Save</button>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-i18n="task_affairs.cancel">Cancel</button>
         </div>
       </form>
     </div>
@@ -68,15 +75,15 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
 </div>
 <?php endforeach; ?>
 <br><br>
-<h4>新建具体事务</h4>
+<h4 data-i18n="task_affairs.new_title">New Affair</h4>
 <form method="post" action="affair_add.php">
   <input type="hidden" name="task_id" value="<?= $task_id; ?>">
   <div class="mb-3">
-    <label class="form-label">具体事务描述</label>
+    <label class="form-label" data-i18n="task_affairs.label_description">Description</label>
     <textarea name="description" class="form-control" rows="2" required></textarea>
   </div>
   <div class="mb-3">
-    <label class="form-label">负责成员 (按住Ctrl键点选多个人)</label>
+    <label class="form-label" data-i18n="task_affairs.label_members">Members (hold Ctrl to select multiple)</label>
     <select name="member_ids[]" class="form-select" multiple required size="10">
       <?php foreach($members as $m): ?>
       <option value="<?= $m['id']; ?>"><?= htmlspecialchars($m['name']); ?> (<?= $m['campus_id']; ?>)</option>
@@ -84,34 +91,37 @@ $members = $pdo->query("SELECT id, campus_id, name FROM members WHERE status != 
     </select>
   </div>
   <div class="mb-3">
-    <label class="form-label">起始日期</label>
+    <label class="form-label" data-i18n="task_affairs.label_start">Start Date</label>
     <input type="date" name="start_time" id="startDate" class="form-control" required>
   </div>
   <div class="mb-3">
-    <label class="form-label">结束日期</label>
+    <label class="form-label" data-i18n="task_affairs.label_end">End Date</label>
     <input type="date" name="end_time" id="endDate" class="form-control" required>
     <div id="dayCount" class="mt-2"></div>
   </div>
-  <button type="submit" class="btn btn-primary">新增事务</button>
-  <a href="tasks.php" class="btn btn-secondary">返回</a>
+  <button type="submit" class="btn btn-primary" data-i18n="task_affairs.add">Add Affair</button>
+  <a href="tasks.php" class="btn btn-secondary" data-i18n="task_affairs.back">Back</a>
 </form>
 <script>
 const affairForm = document.querySelector('form[action="affair_add.php"]');
 const startField = document.getElementById('startDate');
 const endField = document.getElementById('endDate');
 const dayCount = document.getElementById('dayCount');
+const getLang = () => document.documentElement.lang || 'en';
 function updateDays(){
   if(startField.value && endField.value){
     const start = new Date(startField.value);
     const end = new Date(endField.value);
     const diff = Math.floor((end - start) / (1000*60*60*24)) + 1;
     if(diff <= 0){
-      alert('结束日期必须不早于起始日期');
+      const msg = translations[getLang()]['task_affairs.error.range'];
+      alert(msg);
       endField.value = '';
       dayCount.textContent = '';
       return false;
     }
-    dayCount.textContent = `本次事务工作量：${diff} 天`;
+    const lang = getLang();
+    dayCount.textContent = translations[lang]['task_affairs.workload_prefix'] + diff + translations[lang]['task_affairs.workload_suffix'];
   } else {
     dayCount.textContent = '';
   }
@@ -131,8 +141,16 @@ document.querySelectorAll('.edit-affair-form').forEach(function(form){
     const ed = form.querySelector('.edit-end').value;
     if(s && ed && new Date(ed) < new Date(s)){
       e.preventDefault();
-      alert('结束日期必须不早于起始日期');
+      const msg = translations[getLang()]['task_affairs.error.range'];
+      alert(msg);
     }
+  });
+});
+
+document.querySelectorAll('.delete-affair').forEach(link => {
+  link.addEventListener('click', e => {
+    const msg = translations[getLang()]['task_affairs.confirm.delete'];
+    if(!doubleConfirm(msg)) e.preventDefault();
   });
 });
 </script>

--- a/task_member_fill.php
+++ b/task_member_fill.php
@@ -56,7 +56,7 @@ if($member_id){
 }
 ?>
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -129,7 +129,7 @@ if($member_id){
    </div>
    <button type="submit" class="btn btn-primary">申报该工作量</button>
  </form>
- <script>
+<script>
  const startInput = document.getElementById('startTime');
  const endInput = document.getElementById('endTime');
  const warning = document.getElementById('timeWarning');
@@ -171,5 +171,6 @@ if($member_id){
  });
  </script>
 <?php endif; ?>
+<script src="team_name.js"></script>
 </body>
 </html>

--- a/team_name.js
+++ b/team_name.js
@@ -1,3 +1,26 @@
 // Set your organization or team name here with language variants.
 // Example: const TEAM_NAME = { en: 'ACME ', zh: 'ACME ' };
 const TEAM_NAME = { en: '', zh: '' };
+
+function applyTeamName() {
+  if (typeof TEAM_NAME === 'undefined') return;
+  const lang = localStorage.getItem('lang') || document.documentElement.lang || 'en';
+  const name = typeof TEAM_NAME === 'string' ? TEAM_NAME : (TEAM_NAME[lang] || '');
+  if (!name) return;
+  const regex = /(团队|Team)/g;
+  const replacer = (match, p1, offset, str) => {
+    return str.slice(Math.max(0, offset - name.length), offset) === name ? match : name + match;
+  };
+  document.title = document.title.replace(regex, replacer);
+  (function walk(node) {
+    node.childNodes.forEach(child => {
+      if (child.nodeType === Node.TEXT_NODE) {
+        child.textContent = child.textContent.replace(regex, replacer);
+      } else {
+        walk(child);
+      }
+    });
+  })(document.body);
+}
+
+document.addEventListener('DOMContentLoaded', applyTeamName);

--- a/todolist.php
+++ b/todolist.php
@@ -116,7 +116,13 @@ document.querySelectorAll('.add-item').forEach(btn=>{
 
 function printTodoList(){
   const lang=document.documentElement.lang||'en';
-  let html='<html><head><title>'+document.title+'</title><style>body{font-family:sans-serif;padding:10mm;}h3{margin-top:10mm;}ul{list-style:none;padding-left:0;}li{margin:4px 0;}li.done{text-decoration:line-through;color:#888;}</style></head><body>';
+  let html='<html><head><title>'+document.title+'</title><style>'+
+            'body{font-family:sans-serif;padding:10mm;background:#f9f9f9;}' +
+            'h3{margin-top:10mm;}' +
+            'ul{list-style:none;padding-left:0;}' +
+            'li{margin:4px 0;padding:4px;border-radius:4px;background:#fff;}' +
+            'li.done{text-decoration:line-through;color:#888;background:#e9ecef;}' +
+            '</style></head><body>';
   html+="<h1>待办事项</h1>";
   document.querySelectorAll('.todolist').forEach(list=>{
     if(!list.children.length) return;


### PR DESCRIPTION
## Summary
- fix login page theme and language toggles by initializing handlers reliably
- display configurable team name on login page and member fill form
- add full i18n support for task affairs and enhance todolist print style

## Testing
- `php -l login.php task_affairs.php task_member_fill.php footer.php todolist.php`


------
https://chatgpt.com/codex/tasks/task_e_689d79ae4958832a805066224b264e68