### PR TITLE
Enable affair merging and member join features

### DIFF
--- a/affair_edit.php
+++ b/affair_edit.php
@@ -4,6 +4,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
     $id = $_POST['id'];
     $task_id = $_POST['task_id'];
     $description = $_POST['description'];
+    $member_ids = $_POST['member_ids'] ?? [];
     $start_date = $_POST['start_time'];
     $end_date = $_POST['end_time'];
     if(strtotime($end_date) < strtotime($start_date)){
@@ -14,6 +15,11 @@ if($_SERVER['REQUEST_METHOD'] === 'POST'){
     $end_time = date('Y-m-d 00:00:00', strtotime($end_date . ' +1 day'));
     $stmt = $pdo->prepare('UPDATE task_affairs SET description=?, start_time=?, end_time=? WHERE id=?');
     $stmt->execute([$description,$start_time,$end_time,$id]);
+    $pdo->prepare('DELETE FROM task_affair_members WHERE affair_id=?')->execute([$id]);
+    $insert = $pdo->prepare('INSERT INTO task_affair_members(affair_id,member_id) VALUES (?,?)');
+    foreach($member_ids as $mid){
+        $insert->execute([$id,$mid]);
+    }
     header('Location: task_affairs.php?id=' . $task_id);
     exit();
 }

--- a/affair_merge.php
+++ b/affair_merge.php
@@ -1,0 +1,37 @@
+<?php
+include 'auth_manager.php';
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    $task_id = $_POST['task_id'];
+    $ids = $_POST['affair_ids'] ?? [];
+    if(count($ids) < 2){
+        header('Location: task_affairs.php?id=' . $task_id);
+        exit();
+    }
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $stmt = $pdo->prepare("SELECT * FROM task_affairs WHERE id IN ($placeholders)");
+    $stmt->execute($ids);
+    $affairs = $stmt->fetchAll();
+    if(!$affairs){
+        header('Location: task_affairs.php?id=' . $task_id);
+        exit();
+    }
+    $description = $affairs[0]['description'];
+    $start_time = min(array_column($affairs, 'start_time'));
+    $end_time = max(array_column($affairs, 'end_time'));
+    $memberStmt = $pdo->prepare("SELECT DISTINCT member_id FROM task_affair_members WHERE affair_id IN ($placeholders)");
+    $memberStmt->execute($ids);
+    $members = $memberStmt->fetchAll(PDO::FETCH_COLUMN);
+    $pdo->prepare('INSERT INTO task_affairs(task_id,description,start_time,end_time) VALUES (?,?,?,?)')
+        ->execute([$task_id,$description,$start_time,$end_time]);
+    $new_id = $pdo->lastInsertId();
+    $insert = $pdo->prepare('INSERT INTO task_affair_members(affair_id,member_id) VALUES (?,?)');
+    foreach($members as $mid){
+        $insert->execute([$new_id,$mid]);
+    }
+    $pdo->prepare("DELETE FROM task_affair_members WHERE affair_id IN ($placeholders)")->execute($ids);
+    $pdo->prepare("DELETE FROM task_affairs WHERE id IN ($placeholders)")->execute($ids);
+    header('Location: task_affairs.php?id=' . $task_id);
+    exit();
+}
+header('Location: tasks.php');
+?>


### PR DESCRIPTION
## Summary
- Allow managers to merge selected task affairs and edit their member lists
- Let members join existing affairs and inform them about this capability
- Introduce backend endpoint to aggregate merged affairs and members

## Testing
- `php -l task_affairs.php`
- `php -l affair_edit.php`
- `php -l task_member_fill.php`
- `php -l affair_merge.php`


------
https://chatgpt.com/codex/tasks/task_e_689febcfbdc0832a944c07d307754d21