### PR TITLE
Add vibrant gradient background and hero banner

### DIFF
--- a/header.php
+++ b/header.php
@@ -7,12 +7,41 @@
 <title data-i18n="header.title">Team Management Platform</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 <style>
-  .container { max-width: 80%; }
+  body {
+    min-height: 100vh;
+    background: linear-gradient(-45deg, #ee7752, #e73c7e, #23a6d5, #23d5ab);
+    background-size: 400% 400%;
+    animation: gradientBG 15s ease infinite;
+  }
+  .main-container {
+    max-width: 80%;
+    background-color: rgba(255, 255, 255, 0.85);
+    border-radius: 0.5rem;
+    padding: 2rem;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
+  }
   .member-detail { color: #CCCCCC !important; }
   tr[style*="background-color"] > * { background-color: inherit !important; }
   .navbar-nav .nav-link.active, .navbar-brand.active {
     background-color: rgba(255, 255, 255, 0.25);
     border-radius: 0.25rem;
+  }
+  .hero-banner {
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 1rem;
+    padding: 4rem 2rem;
+    color: #fff;
+    text-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    animation: fadeIn 2s ease;
+  }
+  @keyframes gradientBG {
+    0% {background-position: 0% 50%;}
+    50% {background-position: 100% 50%;}
+    100% {background-position: 0% 50%;}
+  }
+  @keyframes fadeIn {
+    from {opacity: 0; transform: translateY(-20px);}
+    to {opacity: 1; transform: translateY(0);}
   }
 </style>
 </head>
@@ -42,4 +71,4 @@
     </div>
   </div>
 </nav>
-<div class="container">
+<div class="container main-container">

--- a/index.php
+++ b/index.php
@@ -1,4 +1,6 @@
 <?php include 'header.php'; ?>
-<h1 class="mb-4" data-i18n="index.title">Dashboard</h1>
-<p data-i18n="index.info">Use the navigation bar to manage team members, projects, tasks, and workload reports.</p>
+<div class="hero-banner text-center mb-4">
+  <h1 class="display-4 fw-bold mb-3" data-i18n="index.title">Dashboard</h1>
+  <p class="lead" data-i18n="index.info">Use the navigation bar to manage team members, projects, tasks, and workload reports.</p>
+</div>
 <?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- animate the site background with a shifting gradient for a more colorful look
- wrap page content in a semi-transparent container for readability
- add a fading hero banner to the dashboard for a more lively landing page

## Testing
- `php -l header.php index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2c034e884832a8d94a2fc37d28387