### PR TITLE
Darken navbar and add sliding indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple responsive website for managing research team members, projects, small 
 - Manage Research Directions assigned to each member
 - Manage tasks and their regular affairs
 - Generate workload reports for each member within a time range (exportable to CSV)
+- Animated navigation bar with sliding highlight
 
 ## Requirements
 - PHP 8+
@@ -19,15 +20,38 @@ A simple responsive website for managing research team members, projects, small 
 - Apache with PHP support (LAMP stack)
 
 ## Installation
-1. Prepare LAMP stack on your Linux server.
-2. Clone or download this repository to your web root.
-3. Import the database schema and sample data:
+### Preparing the LAMP stack (Ubuntu example)
+1. Update package index:
+   ```bash
+   sudo apt update
+   ```
+2. Install Apache:
+   ```bash
+   sudo apt install apache2
+   ```
+3. Install MySQL Server:
+   ```bash
+   sudo apt install mysql-server
+   sudo mysql_secure_installation
+   ```
+4. Install PHP and required extensions:
+   ```bash
+   sudo apt install php libapache2-mod-php php-mysql
+   ```
+5. Restart Apache so PHP is enabled:
+   ```bash
+   sudo systemctl restart apache2
+   ```
+
+### Deploying the application
+1. Clone or download this repository to your web root.
+2. Import the database schema and sample data:
    ```bash
    mysql -u root -p < database.sql
    ```
    (Change `root` to your DB user.)
-4. Edit `config.php` if your database credentials differ.
-5. Access the site via `http://your-server/login.php` and log in using one of the predefined accounts:
+3. Edit `config.php` if your database credentials differ.
+4. Access the site via `http://your-server/login.php` and log in using one of the predefined accounts:
    - Username: `manager1`, Password: `password`
    - Username: `manager2`, Password: `password`
 

--- a/app.js
+++ b/app.js
@@ -557,13 +557,17 @@ function initApp() {
       indicator.style.transform = `translateX(${rect.left - navRect.left}px)`;
     }
     const active = nav.querySelector('.nav-link.active');
+    const activeIdx = links.indexOf(active || links[0]);
     const prevIndex = parseInt(sessionStorage.getItem('navActiveIndex'), 10);
+
     if(!isNaN(prevIndex) && links[prevIndex]){
       moveIndicator(links[prevIndex]);
       requestAnimationFrame(()=>moveIndicator(active || links[0]));
     } else {
       moveIndicator(active || links[0]);
     }
+
+    sessionStorage.setItem('navActiveIndex', activeIdx);
     links.forEach((link, idx)=>{
       link.addEventListener('click', ()=>{
         sessionStorage.setItem('navActiveIndex', idx);

--- a/header.php
+++ b/header.php
@@ -23,12 +23,13 @@
   .member-detail { color: #CCCCCC !important; font-weight: normal !important; }
   .navbar {
     position: relative;
-    background: linear-gradient(90deg, #ff7e5f, #feb47b, #86A8E7, #91EAE4);
-    background-size: 300% 300%;
+    background: linear-gradient(90deg, #1f1f1f, #343a40, #212529);
+    background-size: 200% 200%;
     animation: navGradient 15s ease infinite;
   }
   .navbar-nav .nav-link {
     position: relative;
+    z-index: 1;
     color: #fff;
     transition: color 0.3s ease;
   }
@@ -38,11 +39,11 @@
     top: 0;
     left: 0;
     height: 100%;
-    background-color: rgba(255,255,255,0.25);
+    background-color: rgba(255, 255, 255, 0.15);
     border-radius: 0.25rem;
     transition: all 0.3s ease;
     pointer-events: none;
-    z-index: -1;
+    z-index: 0;
   }
   @keyframes navGradient {
     0% {background-position: 0% 50%;}


### PR DESCRIPTION
## Summary
- tone down navbar with darker gradient and improved highlight indicator
- persist navigation selection to animate sliding background between pages
- document LAMP stack setup and deployment steps in README

## Testing
- `php -l header.php`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2c6cd8470832ab70c60f292d74b65