### PR TITLE
Fix nav indicator retains current page for transition

### DIFF
--- a/app.js
+++ b/app.js
@@ -567,10 +567,13 @@ function initApp() {
       moveIndicator(active || links[0]);
     }
 
+    // Remember the currently active navigation index so the indicator can
+    // animate from the previous page's position on the next load. We store
+    // the index of the page being left rather than the destination page.
     sessionStorage.setItem('navActiveIndex', activeIdx);
-    links.forEach((link, idx)=>{
-      link.addEventListener('click', ()=>{
-        sessionStorage.setItem('navActiveIndex', idx);
+    links.forEach(link => {
+      link.addEventListener('click', () => {
+        sessionStorage.setItem('navActiveIndex', activeIdx);
       });
     });
   }


### PR DESCRIPTION
## Summary
- ensure navbar indicator remembers previous page when navigating
- store active index before leaving page for correct animation

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8eefc2c832a80aa5e422875661c