### PR TITLE
Fix nav indicator retains current page for transition

### DIFF
--- a/app.js
+++ b/app.js
@@ -561,16 +561,27 @@ function initApp() {
     const prevIndex = parseInt(sessionStorage.getItem('navActiveIndex'), 10);
 
     if(!isNaN(prevIndex) && links[prevIndex]){
-      moveIndicator(links[prevIndex]);
+      // Place indicator at the previous location without animation so it
+      // doesn't slide in from the left-most position on initial load.
+      const prev = links[prevIndex];
+      indicator.style.transition = 'none';
+      moveIndicator(prev);
+      // Force reflow to ensure the styles above are applied before restoring
+      // the transition for the animated move to the current page.
+      indicator.offsetWidth; // eslint-disable-line no-unused-expressions
+      indicator.style.transition = '';
       requestAnimationFrame(()=>moveIndicator(active || links[0]));
     } else {
       moveIndicator(active || links[0]);
     }
 
+    // Remember the currently active navigation index so the indicator can
+    // animate from the previous page's position on the next load. We store
+    // the index of the page being left rather than the destination page.
     sessionStorage.setItem('navActiveIndex', activeIdx);
-    links.forEach((link, idx)=>{
-      link.addEventListener('click', ()=>{
-        sessionStorage.setItem('navActiveIndex', idx);
+    links.forEach(link => {
+      link.addEventListener('click', () => {
+        sessionStorage.setItem('navActiveIndex', activeIdx);
       });
     });
   }


### PR DESCRIPTION
## Summary
- prevent navbar indicator from jumping in from the left by positioning it at the last active link without animation
- remember previous nav index for smooth indicator slide

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8eefc2c832a80aa5e422875661c