### PR TITLE
Fix registration validation and add copyable QR links

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ const translations = {
     'logout': 'Logout',
     'header.title': 'Team Management Platform',
     'qr.scan': 'Scan to Enter',
+    'qr.copy': 'Copy Link',
     'login.title': 'Manager Login',
     'login.title.manager': 'Manager Login',
     'login.title.member': 'Member Login',
@@ -245,6 +246,7 @@ const translations = {
     'logout': '退出登录',
     'header.title': '团队管理平台',
     'qr.scan': '扫码进入',
+    'qr.copy': '复制链接',
     'login.title': '管理员登录',
     'login.title.manager': '管理员登录',
     'login.title.member': '成员登录',
@@ -537,9 +539,17 @@ function initApp() {
       const img = document.getElementById('qrImage');
       if (img) {
         img.src = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' + encodeURIComponent(fullUrl);
-        const modal = new bootstrap.Modal(document.getElementById('qrModal'));
-        modal.show();
       }
+      const linkInput = document.getElementById('qrLinkInput');
+      if (linkInput) {
+        linkInput.value = fullUrl;
+      }
+      const copyBtn = document.getElementById('qrCopyBtn');
+      if (copyBtn) {
+        copyBtn.onclick = () => navigator.clipboard.writeText(fullUrl);
+      }
+      const modal = new bootstrap.Modal(document.getElementById('qrModal'));
+      modal.show();
     });
   });
 

--- a/footer.php
+++ b/footer.php
@@ -8,6 +8,10 @@
       </div>
       <div class="modal-body text-center">
         <img id="qrImage" src="" alt="QR Code">
+        <div class="input-group mt-3">
+          <input id="qrLinkInput" type="text" class="form-control" readonly>
+          <button id="qrCopyBtn" class="btn btn-outline-secondary" data-i18n="qr.copy">复制链接</button>
+        </div>
       </div>
     </div>
   </div>

--- a/member_self_register.php
+++ b/member_self_register.php
@@ -3,23 +3,28 @@ require 'config.php';
 $error = '';
 $msg = '';
 if(isset($_POST['action']) && $_POST['action'] === 'register'){
-    $campus_id = $_POST['campus_id'];
-    $name = $_POST['name'];
-    $email = $_POST['email'];
-    $identity_number = $_POST['identity_number'];
-    $year_of_join = $_POST['year_of_join'];
-    $current_degree = $_POST['current_degree'];
-    $degree_pursuing = $_POST['degree_pursuing'];
-    $phone = $_POST['phone'];
-    $wechat = $_POST['wechat'];
-    $department = $_POST['department'];
-    $workplace = $_POST['workplace'];
-    $homeplace = $_POST['homeplace'];
-    $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM members');
-    $nextOrder = $orderStmt->fetchColumn();
-    $stmt = $pdo->prepare('INSERT INTO members(campus_id,name,email,identity_number,year_of_join,current_degree,degree_pursuing,phone,wechat,department,workplace,homeplace,status,sort_order) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
-    $stmt->execute([$campus_id,$name,$email,$identity_number,$year_of_join,$current_degree,$degree_pursuing,$phone,$wechat,$department,$workplace,$homeplace,'in_work',$nextOrder]);
-    $msg = '注册成功。';
+    $campus_id = trim($_POST['campus_id']);
+    $name = trim($_POST['name']);
+    $email = trim($_POST['email']) ?: null;
+    $identity_number = trim($_POST['identity_number']) ?: null;
+    $year_of_join = trim($_POST['year_of_join']);
+    $year_of_join = $year_of_join === '' ? null : intval($year_of_join);
+    $current_degree = trim($_POST['current_degree']) ?: null;
+    $degree_pursuing = trim($_POST['degree_pursuing']) ?: null;
+    $phone = trim($_POST['phone']) ?: null;
+    $wechat = trim($_POST['wechat']) ?: null;
+    $department = trim($_POST['department']) ?: null;
+    $workplace = trim($_POST['workplace']) ?: null;
+    $homeplace = trim($_POST['homeplace']) ?: null;
+    try {
+        $orderStmt = $pdo->query('SELECT COALESCE(MAX(sort_order),-1)+1 FROM members');
+        $nextOrder = $orderStmt->fetchColumn();
+        $stmt = $pdo->prepare('INSERT INTO members(campus_id,name,email,identity_number,year_of_join,current_degree,degree_pursuing,phone,wechat,department,workplace,homeplace,status,sort_order) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)');
+        $stmt->execute([$campus_id,$name,$email,$identity_number,$year_of_join,$current_degree,$degree_pursuing,$phone,$wechat,$department,$workplace,$homeplace,'in_work',$nextOrder]);
+        $msg = '注册成功。';
+    } catch (Exception $e) {
+        $error = '注册失败，请检查输入后再试。';
+    }
 }
 ?>
 <!DOCTYPE html>
@@ -36,6 +41,7 @@ if(isset($_POST['action']) && $_POST['action'] === 'register'){
 <body class="container py-5">
 <h2>新成员注册</h2>
 <?php if($msg): ?><div class="alert alert-success mt-3"><?= $msg; ?></div><?php endif; ?>
+<?php if($error): ?><div class="alert alert-danger mt-3"><?= $error; ?></div><?php endif; ?>
 <form method="post" class="mt-4">
   <input type="hidden" name="action" value="register">
   <div class="mb-3">
@@ -48,45 +54,55 @@ if(isset($_POST['action']) && $_POST['action'] === 'register'){
   </div>
   <div class="mb-3">
     <label class="form-label">正式邮箱（学校/单位）</label>
-    <input type="email" name="email" class="form-control">
+    <input type="email" name="email" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">身份证号</label>
-    <input type="text" name="identity_number" class="form-control">
+    <input type="text" name="identity_number" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">入学年份</label>
-    <input type="number" name="year_of_join" class="form-control">
+    <input type="number" name="year_of_join" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">已获学位</label>
-    <input type="text" name="current_degree" class="form-control">
+    <input type="text" name="current_degree" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">当前学历</label>
-    <input type="text" name="degree_pursuing" class="form-control">
+    <input type="text" name="degree_pursuing" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">手机号</label>
-    <input type="text" name="phone" class="form-control">
+    <input type="text" name="phone" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">微信号</label>
-    <input type="text" name="wechat" class="form-control">
+    <input type="text" name="wechat" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">所处学院/单位</label>
-    <input type="text" name="department" class="form-control">
+    <input type="text" name="department" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">学习/工作地点</label>
-    <input type="text" name="workplace" class="form-control">
+    <input type="text" name="workplace" class="form-control" required>
   </div>
   <div class="mb-3">
     <label class="form-label">家庭地址</label>
-    <input type="text" name="homeplace" class="form-control">
+    <input type="text" name="homeplace" class="form-control" required>
   </div>
-  <button type="submit" class="btn btn-primary">提交信息</button>
+  <button type="submit" id="submitBtn" class="btn btn-primary" disabled>提交信息</button>
 </form>
+<script>
+  const form = document.querySelector('form');
+  const submitBtn = document.getElementById('submitBtn');
+  function checkRequired(){
+    const allFilled = Array.from(form.querySelectorAll('input[required]')).every(i => i.value.trim() !== '');
+    submitBtn.disabled = !allFilled;
+  }
+  form.querySelectorAll('input[required]').forEach(i => i.addEventListener('input', checkRequired));
+  checkRequired();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Prevent blank submissions by sanitizing inputs and disabling register button until all fields are complete
- Show copyable URL beneath QR codes with a one-click copy button

## Testing
- `php -l member_self_register.php`
- `php -l footer.php`
- `node --check app.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68a2cf00c94c832aa3277b9045121689