### PR TITLE
Improve todolist interactions and copy support

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,6 +162,10 @@ const translations = {
     'todolist.export': 'Export',
     'todolist.print': 'Print',
     'todolist.copy_next': 'Continue to Next Week',
+    'todolist.copy_item': 'Copy',
+    'todolist.week.current': 'Current Week',
+    'todolist.week.last': 'Last Week',
+    'todolist.week.next': 'Next Week',
     'todolist.category.work': 'Work',
     'todolist.category.personal': 'Personal',
     'todolist.category.longterm': 'Long Term',
@@ -396,6 +400,10 @@ const translations = {
     'todolist.export': '导出',
     'todolist.print': '打印',
     'todolist.copy_next': '复制到下周',
+    'todolist.copy_item': '复制',
+    'todolist.week.current': '本周',
+    'todolist.week.last': '上周',
+    'todolist.week.next': '下周',
     'todolist.category.work': '工作',
     'todolist.category.personal': '私人',
     'todolist.category.longterm': '长期',
@@ -473,6 +481,22 @@ function doubleConfirm(message) {
   return confirm(message) && confirm('Please confirm again to proceed.');
 }
 
+function copyText(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).catch(fallback);
+  }
+  fallback();
+  function fallback() {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    try { document.execCommand('copy'); } finally { textarea.remove(); }
+  }
+}
+
 function applyTranslations() {
   const lang = localStorage.getItem('lang') || 'en';
   document.documentElement.lang = lang;
@@ -546,7 +570,7 @@ function initApp() {
       }
       const copyBtn = document.getElementById('qrCopyBtn');
       if (copyBtn) {
-        copyBtn.onclick = () => navigator.clipboard.writeText(fullUrl);
+        copyBtn.onclick = () => copyText(fullUrl);
       }
       const modal = new bootstrap.Modal(document.getElementById('qrModal'));
       modal.show();

--- a/todolist_save.php
+++ b/todolist_save.php
@@ -37,5 +37,12 @@ if($action === 'update'){
     $stmt = $pdo->prepare('INSERT INTO todolist_items (user_id,user_role,week_start,category,day,content,is_done,sort_order) SELECT user_id,user_role,?,category,day,content,0,sort_order FROM todolist_items WHERE user_id=? AND user_role=? AND week_start=? AND is_done=0');
     $stmt->execute([$next_week_start,$user_id,$role,$week_start]);
     echo json_encode(['status'=>'ok']);
+} elseif($action === 'copy_item_next'){
+    $id = $data['id'];
+    $week_start = $data['week_start'];
+    $next_week_start = date('Y-m-d', strtotime($week_start.' +7 days'));
+    $stmt = $pdo->prepare('INSERT INTO todolist_items (user_id,user_role,week_start,category,day,content,is_done,sort_order) SELECT user_id,user_role,?,category,day,content,0,sort_order FROM todolist_items WHERE id=? AND user_id=? AND user_role=?');
+    $stmt->execute([$next_week_start,$id,$user_id,$role]);
+    echo json_encode(['status'=>'ok']);
 }
 ?>


### PR DESCRIPTION
## Summary
- Add cross-browser `copyText` helper and use it for QR link copying
- Enable drag-and-drop across week/day categories and per-item copy & next-week buttons
- Highlight current, last, and next weeks with automatic week switching

## Testing
- `php -l todolist.php todolist_save.php`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3cfea9d78832a9aace83a334d5a0d