### PR TITLE
Fix QR modal copy, todo layout, and drag persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -556,24 +556,27 @@ function initApp() {
     });
   }
 
-  document.querySelectorAll('.qr-btn').forEach(btn => {
+  const qrLinkInput = document.getElementById('qrLinkInput');
+  const qrCopyBtn = document.getElementById('qrCopyBtn');
+  const qrButtons = document.querySelectorAll('.qr-btn');
+  if (qrCopyBtn && qrLinkInput) {
+    qrCopyBtn.addEventListener('click', e => {
+      e.preventDefault();
+      copyText(qrLinkInput.value);
+    });
+  }
+  qrButtons.forEach(btn => {
     btn.addEventListener('click', () => {
       const url = btn.dataset.url;
       const fullUrl = new URL(url, window.location.href).href;
       const img = document.getElementById('qrImage');
       if (img) {
-        img.src = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' + encodeURIComponent(fullUrl);
+        img.src =
+          'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=' +
+          encodeURIComponent(fullUrl);
       }
-      const linkInput = document.getElementById('qrLinkInput');
-      if (linkInput) {
-        linkInput.value = fullUrl;
-      }
-      const copyBtn = document.getElementById('qrCopyBtn');
-      if (copyBtn) {
-        copyBtn.addEventListener('click', e => {
-          e.preventDefault();
-          copyText(fullUrl);
-        });
+      if (qrLinkInput) {
+        qrLinkInput.value = fullUrl;
       }
       const modal = new bootstrap.Modal(document.getElementById('qrModal'));
       modal.show();

--- a/todolist.php
+++ b/todolist.php
@@ -36,7 +36,9 @@ $days = ['mon'=>'周一','tue'=>'周二','wed'=>'周三','thu'=>'周四','fri'=>
 ?>
 <style>
 .todolist li{flex-wrap:nowrap;}
-.todolist li .item-content{flex:1 1 auto;min-width:0;}
+.todolist li .item-content{flex:1 1 auto;min-width:0;max-width:60%;}
+.todolist li .copy-item,
+.todolist li .next-week-item{flex:0 0 auto;white-space:nowrap;min-width:5.5rem;}
 @media print {
   @page { size: A4; margin: 10mm; }
   body { font-size: 12pt; }

--- a/todolist_save.php
+++ b/todolist_save.php
@@ -12,8 +12,8 @@ if($action === 'update'){
     $day = $data['day'] ?: null;
     $week_start = $data['week_start'];
     if($id){
-        $stmt = $pdo->prepare('UPDATE todolist_items SET content=?, is_done=? WHERE id=? AND user_id=? AND user_role=?');
-        $stmt->execute([$content,$is_done,$id,$user_id,$role]);
+        $stmt = $pdo->prepare('UPDATE todolist_items SET content=?, is_done=?, category=?, day=? WHERE id=? AND user_id=? AND user_role=?');
+        $stmt->execute([$content,$is_done,$category,$day,$id,$user_id,$role]);
         echo json_encode(['id'=>$id]);
     } else {
         $stmt = $pdo->prepare('INSERT INTO todolist_items (user_id,user_role,week_start,category,day,content,is_done,sort_order) VALUES (?,?,?,?,?,?,?,0)');


### PR DESCRIPTION
## Summary
- Ensure QR modal's copy button writes link to clipboard reliably
- Keep todo list action buttons on one line by limiting input width
- Persist category changes when dragging todo items between lists

## Testing
- `php -l todolist.php`
- `php -l todolist_save.php`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3d79a5318832ab910c7a701d5f560