### PR TITLE
Add reimbursement announcement feature

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -146,3 +146,9 @@ CREATE TABLE reimbursement_receipts (
   FOREIGN KEY (batch_id) REFERENCES reimbursement_batches(id) ON DELETE CASCADE,
   FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE
 );
+
+CREATE TABLE reimbursement_announcement (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  content TEXT NOT NULL
+);
+INSERT INTO reimbursement_announcement (id, content) VALUES (1, '');

--- a/reimbursement_announcement_edit.php
+++ b/reimbursement_announcement_edit.php
@@ -1,0 +1,22 @@
+<?php
+include 'auth_manager.php';
+$announcement = $pdo->query("SELECT content FROM reimbursement_announcement WHERE id=1")->fetchColumn();
+if($_SERVER['REQUEST_METHOD'] === 'POST'){
+    $content = $_POST['content'];
+    $stmt = $pdo->prepare("UPDATE reimbursement_announcement SET content=? WHERE id=1");
+    $stmt->execute([$content]);
+    header('Location: reimbursements.php');
+    exit();
+}
+include 'header.php';
+?>
+<h2>Reimbursement Announcement</h2>
+<form method="post">
+  <div class="mb-3">
+    <textarea name="content" class="form-control" rows="6"><?= htmlspecialchars($announcement); ?></textarea>
+    <div class="form-text">You can use HTML tags for styling.</div>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="reimbursements.php" class="btn btn-secondary">Cancel</a>
+</form>
+<?php include 'footer.php'; ?>

--- a/reimbursements.php
+++ b/reimbursements.php
@@ -4,7 +4,7 @@ include 'header.php';
 $is_manager = ($_SESSION['role'] === 'manager');
 $member_id = $_SESSION['member_id'] ?? null;
 
-if($is_manager && $_SERVER['REQUEST_METHOD'] === 'POST'){
+if($is_manager && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['title'])){
     $id = $_POST['id'] ?? '';
     $title = trim($_POST['title']);
     $incharge = $_POST['in_charge'] ?: null;
@@ -21,7 +21,18 @@ if($is_manager && $_SERVER['REQUEST_METHOD'] === 'POST'){
 
 $batches = $pdo->query("SELECT b.*, m.name AS in_charge_name, (SELECT COUNT(*) FROM reimbursement_receipts r WHERE r.batch_id=b.id) AS receipt_count FROM reimbursement_batches b LEFT JOIN members m ON b.in_charge_member_id=m.id ORDER BY (b.status='completed'), b.deadline ASC")->fetchAll();
 $members = $pdo->query("SELECT id, name FROM members ORDER BY name")->fetchAll();
+$announcement = $pdo->query("SELECT content FROM reimbursement_announcement WHERE id=1")->fetchColumn();
 ?>
+<?php if($announcement || $is_manager): ?>
+<div class="alert alert-warning">
+  <?php if($announcement): ?>
+  <?= nl2br($announcement); ?>
+  <?php endif; ?>
+  <?php if($is_manager): ?>
+  <a href="reimbursement_announcement_edit.php" class="btn btn-sm btn-light ms-3">Edit Announcement</a>
+  <?php endif; ?>
+</div>
+<?php endif; ?>
 <div class="d-flex justify-content-between mb-3">
   <h2 data-i18n="reimburse.title">Reimbursement Batches</h2>
   <div>

--- a/update_db.sql
+++ b/update_db.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS reimbursement_announcement (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  content TEXT NOT NULL
+);
+INSERT INTO reimbursement_announcement (id, content) VALUES (1, '') ON DUPLICATE KEY UPDATE content=content;


### PR DESCRIPTION
## Summary
- Display highlighted announcement on reimbursement page for members and managers
- Allow managers to edit announcement content via dedicated page
- Store announcement text in new `reimbursement_announcement` table with upgrade script

## Testing
- `php -l reimbursements.php`
- `php -l reimbursement_announcement_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68a57862a16c832ab1b4c12b30906a13