### PR TITLE
Add bilingual reimbursement announcement and fix HTML line breaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -326,7 +326,12 @@ const translations = {
   'reimburse.batch.total_member': 'Total by Member',
   'reimburse.batch.total_category': 'Total by Category',
   'reimburse.batch.campus_id': 'Campus ID',
-  'reimburse.batch.total': 'Total'
+  'reimburse.batch.total': 'Total',
+  'reimburse.announcement.title': 'Reimbursement Announcement',
+  'reimburse.announcement.label_en': 'English Announcement',
+  'reimburse.announcement.label_zh': 'Chinese Announcement',
+  'reimburse.announcement.edit': 'Edit Announcement',
+  'reimburse.announcement.note_html': 'You can use HTML tags for styling.'
   },
   zh: {
     'nav.home': '团队管理',
@@ -655,7 +660,12 @@ const translations = {
   'reimburse.batch.total_member': '成员金额汇总',
   'reimburse.batch.total_category': '类别金额汇总',
   'reimburse.batch.campus_id': '学号',
-  'reimburse.batch.total': '总金额'
+  'reimburse.batch.total': '总金额',
+  'reimburse.announcement.title': '报销公告',
+  'reimburse.announcement.label_en': '英文公告',
+  'reimburse.announcement.label_zh': '中文公告',
+  'reimburse.announcement.edit': '编辑公告',
+  'reimburse.announcement.note_html': '可以使用HTML标签进行排版'
   }
 };
 

--- a/database.sql
+++ b/database.sql
@@ -149,6 +149,7 @@ CREATE TABLE reimbursement_receipts (
 
 CREATE TABLE reimbursement_announcement (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  content TEXT NOT NULL
+  content_en TEXT NOT NULL,
+  content_zh TEXT NOT NULL
 );
-INSERT INTO reimbursement_announcement (id, content) VALUES (1, '');
+INSERT INTO reimbursement_announcement (id, content_en, content_zh) VALUES (1, '', '');

--- a/reimbursement_announcement_edit.php
+++ b/reimbursement_announcement_edit.php
@@ -1,22 +1,29 @@
 <?php
 include 'auth_manager.php';
-$announcement = $pdo->query("SELECT content FROM reimbursement_announcement WHERE id=1")->fetchColumn();
+$announcement = $pdo->query("SELECT content_en, content_zh FROM reimbursement_announcement WHERE id=1")
+                    ->fetch(PDO::FETCH_ASSOC);
 if($_SERVER['REQUEST_METHOD'] === 'POST'){
-    $content = $_POST['content'];
-    $stmt = $pdo->prepare("UPDATE reimbursement_announcement SET content=? WHERE id=1");
-    $stmt->execute([$content]);
+    $content_en = $_POST['content_en'];
+    $content_zh = $_POST['content_zh'];
+    $stmt = $pdo->prepare("UPDATE reimbursement_announcement SET content_en=?, content_zh=? WHERE id=1");
+    $stmt->execute([$content_en, $content_zh]);
     header('Location: reimbursements.php');
     exit();
 }
 include 'header.php';
 ?>
-<h2>Reimbursement Announcement</h2>
+<h2 data-i18n="reimburse.announcement.title">Reimbursement Announcement</h2>
 <form method="post">
   <div class="mb-3">
-    <textarea name="content" class="form-control" rows="6"><?= htmlspecialchars($announcement); ?></textarea>
-    <div class="form-text">You can use HTML tags for styling.</div>
+    <label class="form-label" data-i18n="reimburse.announcement.label_en">English Announcement</label>
+    <textarea name="content_en" class="form-control" rows="4"><?= htmlspecialchars($announcement['content_en'] ?? ''); ?></textarea>
   </div>
-  <button type="submit" class="btn btn-primary">Save</button>
-  <a href="reimbursements.php" class="btn btn-secondary">Cancel</a>
+  <div class="mb-3">
+    <label class="form-label" data-i18n="reimburse.announcement.label_zh">Chinese Announcement</label>
+    <textarea name="content_zh" class="form-control" rows="4"><?= htmlspecialchars($announcement['content_zh'] ?? ''); ?></textarea>
+    <div class="form-text" data-i18n="reimburse.announcement.note_html">You can use HTML tags for styling.</div>
+  </div>
+  <button type="submit" class="btn btn-primary" data-i18n="reimburse.batch.save">Save</button>
+  <a href="reimbursements.php" class="btn btn-secondary" data-i18n="reimburse.batch.cancel">Cancel</a>
 </form>
 <?php include 'footer.php'; ?>

--- a/reimbursements.php
+++ b/reimbursements.php
@@ -21,17 +21,24 @@ if($is_manager && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['title']
 
 $batches = $pdo->query("SELECT b.*, m.name AS in_charge_name, (SELECT COUNT(*) FROM reimbursement_receipts r WHERE r.batch_id=b.id) AS receipt_count FROM reimbursement_batches b LEFT JOIN members m ON b.in_charge_member_id=m.id ORDER BY (b.status='completed'), b.deadline ASC")->fetchAll();
 $members = $pdo->query("SELECT id, name FROM members ORDER BY name")->fetchAll();
-$announcement = $pdo->query("SELECT content FROM reimbursement_announcement WHERE id=1")->fetchColumn();
+$announcement = $pdo->query("SELECT content_en, content_zh FROM reimbursement_announcement WHERE id=1")
+                ->fetch(PDO::FETCH_ASSOC);
 ?>
-<?php if($announcement || $is_manager): ?>
+<?php if(($announcement['content_en'] ?? '') || ($announcement['content_zh'] ?? '') || $is_manager): ?>
 <div class="alert alert-warning">
-  <?php if($announcement): ?>
-  <?= nl2br($announcement); ?>
+  <?php if(($announcement['content_en'] ?? '') || ($announcement['content_zh'] ?? '')): ?>
+  <div class="announcement" data-lang="en"><?= $announcement['content_en']; ?></div>
+  <div class="announcement" data-lang="zh"><?= $announcement['content_zh']; ?></div>
   <?php endif; ?>
   <?php if($is_manager): ?>
-  <a href="reimbursement_announcement_edit.php" class="btn btn-sm btn-light ms-3">Edit Announcement</a>
+  <a href="reimbursement_announcement_edit.php" class="btn btn-sm btn-light ms-3" data-i18n="reimburse.announcement.edit">Edit Announcement</a>
   <?php endif; ?>
 </div>
+<style>
+.announcement[data-lang]{display:none;}
+html[lang="en"] .announcement[data-lang="en"]{display:block;}
+html[lang="zh"] .announcement[data-lang="zh"]{display:block;}
+</style>
 <?php endif; ?>
 <div class="d-flex justify-content-between mb-3">
   <h2 data-i18n="reimburse.title">Reimbursement Batches</h2>


### PR DESCRIPTION
## Summary
- store reimbursement announcements in English and Chinese with editable fields
- display the announcement in the viewer's language without injecting unwanted `<br>` tags
- add translation keys and database schema for bilingual announcements

## Testing
- `php -l reimbursement_announcement_edit.php`
- `php -l reimbursements.php`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a57b906978832aaee69c7c735abc2a