### PR TITLE
Handle oversized regulation uploads

### DIFF
--- a/regulation_edit.php
+++ b/regulation_edit.php
@@ -21,11 +21,17 @@ if($id){
 $error = '';
 if($_SERVER['REQUEST_METHOD']==='POST'){
     $isAjax = isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
-    $category = trim($_POST['category'] ?? '');
-    $description = trim($_POST['description'] ?? '');
     $errors = [];
-    if($category === '' || $description === ''){
-        $errors[] = 'Category and description are required';
+    if(empty($_POST) && empty($_FILES) && ($_SERVER['CONTENT_LENGTH'] ?? 0) > 0){
+        $errors[] = 'File too large';
+        $category = '';
+        $description = '';
+    }else{
+        $category = trim($_POST['category'] ?? '');
+        $description = trim($_POST['description'] ?? '');
+        if($category === '' || $description === ''){
+            $errors[] = 'Category and description are required';
+        }
     }
     if(!$errors){
         if($id){


### PR DESCRIPTION
## Summary
- Detect when regulation uploads exceed PHP's size limits and return a "File too large" error
- Preserve original validation for category and description when uploads are within limits

## Testing
- `php -l regulation_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac3b27c63c832a91b722a1f151ea81