### PR TITLE
Fix duplicated regulation items display

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@ foreach($regulations as &$r){
     $stmt->execute([$r['id']]);
     $r['files'] = $stmt->fetchAll();
 }
+unset($r);
 if($_SESSION['role']==='member'){
     $member_id = $_SESSION['member_id'];
     $pdo->prepare('UPDATE notification_targets nt JOIN notifications n ON nt.notification_id=n.id SET nt.status="seen" WHERE nt.member_id=? AND nt.status="sent" AND n.is_revoked=0 AND CURDATE() BETWEEN n.valid_begin_date AND n.valid_end_date')->execute([$member_id]);

--- a/notifications.php
+++ b/notifications.php
@@ -9,6 +9,7 @@ foreach($regulations as &$r){
     $stmt->execute([$r['id']]);
     $r['files'] = $stmt->fetchAll();
 }
+unset($r);
 ?>
 <div class="d-flex justify-content-between mb-3">
   <h2 data-i18n="notifications.title">Notifications</h2>


### PR DESCRIPTION
## Summary
- Prevent duplicated regulations by clearing reference after building regulation list
- Apply same fix on index page

## Testing
- `php -l notifications.php index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad192b1fc4832aba006f6beaa7fb27