### PR TITLE
Add unique suffix to reimbursement receipt filenames

### DIFF
--- a/reimbursement_batch.php
+++ b/reimbursement_batch.php
@@ -62,6 +62,9 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
                     $orig = $_FILES['receipt']['name'];
                     $ext = strtolower(pathinfo($orig, PATHINFO_EXTENSION));
                     $tmpPath = $_FILES['receipt']['tmp_name'];
+                    $orig_base = pathinfo($orig, PATHINFO_FILENAME);
+                    $suffix = mt_rand(1000,9999) . '-' . time();
+                    $orig = $orig_base . '-' . $suffix . '.' . $ext;
                     if($ext === 'pdf'){
                         $keywords=$pdo->query("SELECT keyword FROM reimbursement_prohibited_keywords")->fetchAll(PDO::FETCH_COLUMN);
                         $content=@shell_exec('pdftotext '.escapeshellarg($tmpPath).' -');
@@ -81,7 +84,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
                         $countStmt->execute([$id,$member_id]);
                         $index = $countStmt->fetchColumn()+1;
                         $base = $mi['name'].'-'.$mi['campus_id'].'-'.$batch['title'].'-'.$index;
-                        $newname = $base.'.'.$ext;
+                        $newname = $base . '-' . $suffix . '.' . $ext;
                         $dir = __DIR__.'/reimburse_uploads/'.$id;
                         if(!is_dir($dir)) mkdir($dir,0777,true);
                         move_uploaded_file($tmpPath, $dir.'/'.$newname);

--- a/reimbursement_receipt_edit.php
+++ b/reimbursement_receipt_edit.php
@@ -64,6 +64,9 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
                     $orig = $_FILES['receipt']['name'];
                     $ext = strtolower(pathinfo($orig, PATHINFO_EXTENSION));
                     $tmpPath = $_FILES['receipt']['tmp_name'];
+                    $orig_base = pathinfo($orig, PATHINFO_FILENAME);
+                    $suffix = mt_rand(1000,9999) . '-' . time();
+                    $orig = $orig_base . '-' . $suffix . '.' . $ext;
                     if($ext==='pdf'){
                         $keywords=$pdo->query("SELECT keyword FROM reimbursement_prohibited_keywords")->fetchAll(PDO::FETCH_COLUMN);
                         $content=@shell_exec('pdftotext '.escapeshellarg($tmpPath).' -');
@@ -76,7 +79,7 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
                         }
                     }
                     if(!$error){
-                        $stored = $base.'.'.$ext;
+                        $stored = $base . '-' . $suffix . '.' . $ext;
                         $dir = __DIR__.'/reimburse_uploads/'.$target_batch_id;
                         if(!is_dir($dir)) mkdir($dir,0777,true);
                         move_uploaded_file($tmpPath, $dir.'/'.$stored);
@@ -85,8 +88,9 @@ if($_SERVER['REQUEST_METHOD']==='POST'){
                 }
             } else {
                 $ext = pathinfo($stored, PATHINFO_EXTENSION);
-                    $newname = $base.'.'.$ext;
-                    if($target_batch_id != $rec['batch_id'] || $newname != $stored){
+                    $storedBase = pathinfo($stored, PATHINFO_FILENAME);
+                    if($target_batch_id != $rec['batch_id'] || strpos($storedBase, $base . '-') !== 0){
+                        $newname = $base . '-' . mt_rand(1000,9999) . '-' . time() . '.' . $ext;
                         $src = __DIR__.'/reimburse_uploads/'.$rec['batch_id'].'/'.$stored;
                         $dir = __DIR__.'/reimburse_uploads/'.$target_batch_id;
                         if(!is_dir($dir)) mkdir($dir,0777,true);


### PR DESCRIPTION
## Summary
- Append random number and timestamp to receipt filenames on upload to prevent collisions
- Ensure both original and stored filenames receive unique suffixes
- Update edit workflow to rename existing files with the same policy when needed

## Testing
- `php -l reimbursement_batch.php`
- `php -l reimbursement_receipt_edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68b989377ea0832aa4c303977efcd51b